### PR TITLE
feat: add attribute go-to-definition to standard YAML

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -54,10 +54,12 @@
     "npm:chokidar-cli@3.0.0": "3.0.0",
     "npm:js-yaml@4.1.0": "4.1.0",
     "npm:js-yaml@^4.1.0": "4.1.0",
-    "npm:tsup@8.4.0": "8.4.0_esbuild@0.25.0_typescript@5.8.2",
-    "npm:tsup@^8.4.0": "8.4.0_esbuild@0.25.0_typescript@5.8.2",
+    "npm:tsup@8.4.0": "8.4.0_typescript@5.8.2_esbuild@0.25.0_yaml@2.8.2",
+    "npm:tsup@^8.4.0": "8.4.0_typescript@5.8.2_esbuild@0.25.0_yaml@2.8.2",
     "npm:typescript@^5.8.2": "5.8.2",
-    "npm:vscode@*": "1.1.37"
+    "npm:vscode@*": "1.1.37",
+    "npm:yaml@2": "2.8.2",
+    "npm:yaml@^2.8.2": "2.8.2"
   },
   "jsr": {
     "@cliffy/command@1.0.0-rc.7": {
@@ -842,13 +844,13 @@
     "agent-base@6.0.2": {
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dependencies": [
-        "debug@4.3.7"
+        "debug@4.4.0"
       ]
     },
     "agent-base@7.1.1": {
       "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
       "dependencies": [
-        "debug@4.3.7"
+        "debug@4.4.0"
       ]
     },
     "ansi-regex@4.1.1": {
@@ -987,7 +989,7 @@
       "dependencies": [
         "ansi-styles@3.2.1",
         "escape-string-regexp",
-        "supports-color@5.5.0"
+        "supports-color"
       ]
     },
     "cheerio-select@2.1.0": {
@@ -1129,12 +1131,6 @@
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dependencies": [
         "ms@2.0.0"
-      ]
-    },
-    "debug@4.3.7": {
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dependencies": [
-        "ms@2.1.3"
       ]
     },
     "debug@4.4.0": {
@@ -1384,6 +1380,7 @@
         "package-json-from-dist",
         "path-scurry@1.11.1"
       ],
+      "deprecated": true,
       "bin": true
     },
     "glob@11.0.0": {
@@ -1396,6 +1393,7 @@
         "package-json-from-dist",
         "path-scurry@2.0.0"
       ],
+      "deprecated": true,
       "bin": true
     },
     "glob@7.1.2": {
@@ -1483,14 +1481,14 @@
       "dependencies": [
         "@tootallnate/once",
         "agent-base@6.0.2",
-        "debug@4.3.7"
+        "debug@4.4.0"
       ]
     },
     "http-proxy-agent@7.0.2": {
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dependencies": [
         "agent-base@7.1.1",
-        "debug@4.3.7"
+        "debug@4.4.0"
       ]
     },
     "https-proxy-agent@2.2.4": {
@@ -1504,14 +1502,14 @@
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dependencies": [
         "agent-base@6.0.2",
-        "debug@4.3.7"
+        "debug@4.4.0"
       ]
     },
     "https-proxy-agent@7.0.5": {
       "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
       "dependencies": [
         "agent-base@7.1.1",
-        "debug@4.3.7"
+        "debug@4.4.0"
       ]
     },
     "iconv-lite@0.6.3": {
@@ -1822,7 +1820,7 @@
         "he",
         "minimatch@3.0.4",
         "mkdirp",
-        "supports-color@5.4.0"
+        "supports-color"
       ],
       "bin": true
     },
@@ -1968,10 +1966,14 @@
     "pluralize@8.0.0": {
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
     },
-    "postcss-load-config@6.0.1": {
+    "postcss-load-config@6.0.1_yaml@2.8.2": {
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
       "dependencies": [
-        "lilconfig"
+        "lilconfig",
+        "yaml"
+      ],
+      "optionalPeers": [
+        "yaml"
       ]
     },
     "prebuild-install@7.1.2": {
@@ -2238,12 +2240,6 @@
         "has-flag"
       ]
     },
-    "supports-color@5.5.0": {
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": [
-        "has-flag"
-      ]
-    },
     "tar-fs@2.1.1": {
       "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "dependencies": [
@@ -2310,7 +2306,7 @@
     "tslib@2.7.0": {
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
-    "tsup@8.4.0_esbuild@0.25.0_typescript@5.8.2": {
+    "tsup@8.4.0_typescript@5.8.2_esbuild@0.25.0_yaml@2.8.2": {
       "integrity": "sha512-b+eZbPCjz10fRryaAA7C8xlIHnf8VnsaRqydheLIqwG/Mcpfk8Z5zp3HayX7GaTygkigHl5cBUs+IhcySiIexQ==",
       "dependencies": [
         "bundle-require",
@@ -2411,7 +2407,8 @@
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
       "dependencies": [
         "iconv-lite"
-      ]
+      ],
+      "deprecated": true
     },
     "whatwg-mimetype@4.0.0": {
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="
@@ -2480,6 +2477,10 @@
     "yaml-ast-parser@0.0.43": {
       "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="
     },
+    "yaml@2.8.2": {
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "bin": true
+    },
     "yargs-parser@13.1.2": {
       "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dependencies": [
@@ -2543,7 +2544,8 @@
       "bdl-vscode": {
         "dependencies": [
           "jsr:@std/yaml@1",
-          "npm:@types/vscode@*"
+          "npm:@types/vscode@*",
+          "npm:yaml@2"
         ],
         "packageJson": {
           "dependencies": [
@@ -2551,7 +2553,8 @@
             "npm:@types/vscode@^1.92.0",
             "npm:@vscode/vsce@^3.1.1",
             "npm:chokidar-cli@3",
-            "npm:js-yaml@^4.1.0"
+            "npm:js-yaml@^4.1.0",
+            "npm:yaml@^2.8.2"
           ]
         }
       }


### PR DESCRIPTION
## Summary
- add go-to-definition support for BDL attributes by resolving their slot and key to the matching entry in the active standard YAML
- use YAML CST-aware node range extraction for precise target selection in standard files
- include updated lockfile changes required by the extension yaml parser dependency graph

## Verification
- `pnpm run build:ts` (in `bdl-vscode`)