### PR TITLE
feat: add package global standard for shared validation

### DIFF
--- a/bdl-ts/deno.json
+++ b/bdl-ts/deno.json
@@ -25,7 +25,8 @@
     "./parser": "./src/parser/bdl/ast-parser.ts",
     "./parser/cst": "./src/parser/bdl/cst-parser.ts",
     "./formatter/bdl": "./src/formatter/bdl.ts",
-    "./standards/conventional": "./src/conventional/standard.ts"
+    "./standards/conventional": "./src/conventional/standard.ts",
+    "./standards/global": "./src/global/standard.ts"
   },
   "imports": {
     "@cliffy/command": "jsr:@cliffy/command@1.0.0-rc.7",

--- a/bdl-ts/src/generated/json/global.json
+++ b/bdl-ts/src/generated/json/global.json
@@ -1,0 +1,13 @@
+{
+  "name": "Global BDL Standard",
+  "description": "Shared attributes applied to all BDL standards.",
+  "primitives": {},
+  "attributes": {
+    "bdl.module": [
+      {
+        "key": "standard",
+        "description": "Specifies which BDL standard should be applied to this module."
+      }
+    ]
+  }
+}

--- a/bdl-ts/src/global/standard.ts
+++ b/bdl-ts/src/global/standard.ts
@@ -1,0 +1,6 @@
+import type { BdlStandard } from "../generated/standard.ts";
+import standard from "../generated/json/global.json" with {
+  type: "json",
+};
+
+export default standard as unknown as BdlStandard;

--- a/bdl-ts/tasks/gen-bdl-ts-model.ts
+++ b/bdl-ts/tasks/gen-bdl-ts-model.ts
@@ -31,6 +31,14 @@ await Deno.writeTextFile(
   JSON.stringify(ir, null, 2),
 );
 
+const globalYamlText = await Deno.readTextFile(
+  resolve(repoRoot, "standards/global.yaml"),
+);
+await Deno.writeTextFile(
+  resolve(repoRoot, "bdl-ts/src/generated/json/global.json"),
+  JSON.stringify(parseYaml(globalYamlText), null, 2),
+);
+
 const conventionalYamlText = await Deno.readTextFile(
   resolve(repoRoot, "standards/conventional.yaml"),
 );

--- a/standards/global.yaml
+++ b/standards/global.yaml
@@ -1,0 +1,10 @@
+name: Global BDL Standard
+description: Shared attributes applied to all BDL standards.
+
+primitives: {}
+
+attributes:
+  bdl.module:
+    - key: standard
+      description: |-
+        Specifies which BDL standard should be applied to this module.


### PR DESCRIPTION
## Summary
- add a new global standard source at `standards/global.yaml` and generate/export it from `@disjukr/bdl` via `./standards/global`
- update VSCode diagnostics to validate shared module attributes and primitives from the package global standard instead of hardcoded special-casing
- keep standard fetching paths raw (no merge at retrieval time) and apply global data only at the diagnostics usage points

## Testing
- deno check bdl-vscode/src/main.ts