### PR TITLE
feat: publish bdlc Docker image from bdlc@ tags

### DIFF
--- a/.github/workflows/publish-bdlc-docker.yml
+++ b/.github/workflows/publish-bdlc-docker.yml
@@ -1,0 +1,77 @@
+name: Publish bdlc Docker Image
+
+on:
+  push:
+    tags:
+      - "bdlc@*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Extract Docker tag version
+        id: version
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#bdlc@}"
+          if [ "$VERSION" = "$GITHUB_REF_NAME" ] || [ -z "$VERSION" ]; then
+            echo "Unexpected tag format: $GITHUB_REF_NAME" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Apply version to bdl-ts deno.json
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          deno run -A - <<'EOF'
+          const version = Deno.env.get("VERSION") || "";
+          if (!version) {
+            throw new Error("VERSION is empty");
+          }
+
+          const denoJsonPath = "bdl-ts/deno.json";
+          const denoJsonText = await Deno.readTextFile(denoJsonPath);
+          const denoJson = JSON.parse(denoJsonText);
+          denoJson.version = version;
+          await Deno.writeTextFile(
+            denoJsonPath,
+            `${JSON.stringify(denoJson, null, 2)}\n`,
+          );
+          console.log(`Applied version ${version} to ${denoJsonPath}`);
+          EOF
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/bdlc:${{ steps.version.outputs.version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/bdlc:latest


### PR DESCRIPTION
## Summary
- Add a new GitHub Actions workflow at `.github/workflows/publish-bdlc-docker.yml` that triggers on `bdlc@*.*.*` tags.
- Build and push multi-platform Docker images (`linux/amd64`, `linux/arm64`) to Docker Hub using `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets.
- Align version-update scripting with existing workflow style by using Deno to apply the tag version into `bdl-ts/deno.json` before publish.

## How To Use
- Create and push a tag like `bdlc@0.0.0`.
- The workflow publishes `${DOCKERHUB_USERNAME}/bdlc:0.0.0` and `${DOCKERHUB_USERNAME}/bdlc:latest`.