### PR TITLE
feat: add tag-based JSR publish workflow for bdl-ts

### DIFF
--- a/.github/workflows/publish-bdl-ts-jsr.yml
+++ b/.github/workflows/publish-bdl-ts-jsr.yml
@@ -1,0 +1,50 @@
+name: Publish bdl-ts to JSR
+
+on:
+  push:
+    tags:
+      - "bdl-ts@*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Apply version from tag
+        working-directory: bdl-ts
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          deno run -A - <<'EOF'
+          const tagName = Deno.env.get("GITHUB_REF_NAME") || "";
+          const match = tagName.match(/^bdl-ts@(.+)$/);
+          if (!match) {
+            throw new Error(`Unexpected tag format: ${tagName}`);
+          }
+
+          const denoJsonPath = "deno.json";
+          const denoJsonText = await Deno.readTextFile(denoJsonPath);
+          const denoJson = JSON.parse(denoJsonText);
+          denoJson.version = match[1];
+          await Deno.writeTextFile(
+            denoJsonPath,
+            `${JSON.stringify(denoJson, null, 2)}\n`,
+          );
+          console.log(`Applied version ${match[1]} to ${denoJsonPath}`);
+          EOF
+
+      - name: Publish to JSR
+        working-directory: bdl-ts
+        env:
+          JSR_TOKEN: ${{ secrets.JSR_TOKEN }}
+        run: deno publish --allow-dirty


### PR DESCRIPTION
## Summary
- Add `.github/workflows/publish-bdl-ts-jsr.yml` to publish `bdl-ts` when tags like `bdl-ts@0.0.0` are pushed.
- Apply the version from the tag into `bdl-ts/deno.json` before publish so registry metadata matches the release tag.
- Publish from `bdl-ts` using `deno publish --allow-dirty` with `JSR_TOKEN`.

## Usage
- Push a tag in the format `bdl-ts@<version>`.
- The workflow will run automatically and publish to JSR.

## Required Secret
- `JSR_TOKEN`