### PR TITLE
fix: unblock bdl-ts JSR publish docs resolution

### DIFF
--- a/bdl-ts/src/formatter/bdl.ts
+++ b/bdl-ts/src/formatter/bdl.ts
@@ -1,4 +1,4 @@
-import type { Span } from "@disjukr/bdl/ast";
+import type { Span } from "../generated/ast.ts";
 import type { BdlCst } from "../generated/cst.ts";
 import type * as cst from "../generated/cst.ts";
 import parseBdlCst, { collectWsAndComments } from "../parser/bdl/cst-parser.ts";


### PR DESCRIPTION
## Summary
- replace formatter Span import from `@disjukr/bdl/ast` with local `../generated/ast.ts`
- avoid self-package `jsr:@disjukr/bdl@.../ast` resolution during JSR documentation generation
- verify with `deno test -A` and `deno publish --dry-run --allow-dirty` in `bdl-ts`