### PR TITLE
Align swagger-petstore generation with conventional OAS attributes

### DIFF
--- a/example-schemas/swagger-petstore/generated/petstore/entity.bdl
+++ b/example-schemas/swagger-petstore/generated/petstore/entity.bdl
@@ -22,7 +22,8 @@ struct Order {
   @ example - 7
   quantity?: int32,
 
-  shipDate?: datetime,
+  @ oas_format - date-time
+  shipDate?: string,
 
   @ example - "approved"
   @ description - Order Status

--- a/example-schemas/swagger-petstore/generated/petstore/pet.bdl
+++ b/example-schemas/swagger-petstore/generated/petstore/pet.bdl
@@ -3,76 +3,76 @@
 import swagger.petstore.entity { ApiResponse, Pet, PetStatus }
 
 @ http - PUT /pet
-@ security
+@ oas_security
 | - petstore_auth:
 |     - 'write:pets'
 |     - 'read:pets'
-@ tags - pet
-@ summary - Update an existing pet.
+@ oas_tags - pet
+@ oas_summary - Update an existing pet.
 @ description - Update an existing pet by Id.
 proc UpdatePet = Pet -> UpdatePetOutput throws UpdatePetError
 
 oneof UpdatePetOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - Successful operation
   Pet,
 }
 
 oneof UpdatePetError {
-  @ status - 400
+  @ oas_status - 400
   @ description - Invalid ID supplied
   void,
 
-  @ status - 404
+  @ oas_status - 404
   @ description - Pet not found
   void,
 
-  @ status - 422
+  @ oas_status - 422
   @ description - Validation exception
   void,
 
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }
 
 @ http - POST /pet
-@ security
+@ oas_security
 | - petstore_auth:
 |     - 'write:pets'
 |     - 'read:pets'
-@ tags - pet
-@ summary - Add a new pet to the store.
+@ oas_tags - pet
+@ oas_summary - Add a new pet to the store.
 @ description - Add a new pet to the store.
 proc AddPet = Pet -> AddPetOutput throws AddPetError
 
 oneof AddPetOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - Successful operation
   Pet,
 }
 
 oneof AddPetError {
-  @ status - 400
+  @ oas_status - 400
   @ description - Invalid input
   void,
 
-  @ status - 422
+  @ oas_status - 422
   @ description - Validation exception
   void,
 
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }
 
 @ http - GET /pet/findByStatus
-@ security
+@ oas_security
 | - petstore_auth:
 |     - 'write:pets'
 |     - 'read:pets'
-@ tags - pet
-@ summary - Finds Pets by status.
+@ oas_tags - pet
+@ oas_summary - Finds Pets by status.
 @ description - Multiple status values can be provided with comma separated strings.
 proc FindPetsByStatus =
   FindPetsByStatusInput ->
@@ -85,28 +85,28 @@ struct FindPetsByStatusInput {
 }
 
 oneof FindPetsByStatusOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - successful operation
   Pet[],
 }
 
 oneof FindPetsByStatusError {
-  @ status - 400
+  @ oas_status - 400
   @ description - Invalid status value
   void,
 
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }
 
 @ http - GET /pet/findByTags
-@ security
+@ oas_security
 | - petstore_auth:
 |     - 'write:pets'
 |     - 'read:pets'
-@ tags - pet
-@ summary - Finds Pets by tags.
+@ oas_tags - pet
+@ oas_summary - Finds Pets by tags.
 @ description - Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
 proc FindPetsByTags =
   FindPetsByTagsInput ->
@@ -119,29 +119,29 @@ struct FindPetsByTagsInput {
 }
 
 oneof FindPetsByTagsOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - successful operation
   Pet[],
 }
 
 oneof FindPetsByTagsError {
-  @ status - 400
+  @ oas_status - 400
   @ description - Invalid tag value
   void,
 
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }
 
 @ http - GET /pet/{petId}
-@ security
+@ oas_security
 | - api_key: []
 | - petstore_auth:
 |     - 'write:pets'
 |     - 'read:pets'
-@ tags - pet
-@ summary - Find pet by ID.
+@ oas_tags - pet
+@ oas_summary - Find pet by ID.
 @ description - Returns a single pet.
 proc GetPetById = GetPetByIdInput -> GetPetByIdOutput throws GetPetByIdError
 
@@ -152,32 +152,32 @@ struct GetPetByIdInput {
 }
 
 oneof GetPetByIdOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - successful operation
   Pet,
 }
 
 oneof GetPetByIdError {
-  @ status - 400
+  @ oas_status - 400
   @ description - Invalid ID supplied
   void,
 
-  @ status - 404
+  @ oas_status - 404
   @ description - Pet not found
   void,
 
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }
 
 @ http - POST /pet/{petId}
-@ security
+@ oas_security
 | - petstore_auth:
 |     - 'write:pets'
 |     - 'read:pets'
-@ tags - pet
-@ summary - Updates a pet in the store with form data.
+@ oas_tags - pet
+@ oas_summary - Updates a pet in the store with form data.
 @ description - Updates a pet resource based on the form data.
 proc UpdatePetWithForm =
   UpdatePetWithFormInput ->
@@ -198,28 +198,28 @@ struct UpdatePetWithFormInput {
 }
 
 oneof UpdatePetWithFormOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - successful operation
   Pet,
 }
 
 oneof UpdatePetWithFormError {
-  @ status - 400
+  @ oas_status - 400
   @ description - Invalid input
   void,
 
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }
 
 @ http - DELETE /pet/{petId}
-@ security
+@ oas_security
 | - petstore_auth:
 |     - 'write:pets'
 |     - 'read:pets'
-@ tags - pet
-@ summary - Deletes a pet.
+@ oas_tags - pet
+@ oas_summary - Deletes a pet.
 @ description - Delete a pet.
 proc DeletePet = DeletePetInput -> DeletePetOutput throws DeletePetError
 
@@ -233,28 +233,28 @@ struct DeletePetInput {
 }
 
 oneof DeletePetOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - Pet deleted
   void,
 }
 
 oneof DeletePetError {
-  @ status - 400
+  @ oas_status - 400
   @ description - Invalid pet value
   void,
 
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }
 
 @ http - POST /pet/{petId}/uploadImage
-@ security
+@ oas_security
 | - petstore_auth:
 |     - 'write:pets'
 |     - 'read:pets'
-@ tags - pet
-@ summary - Uploads an image.
+@ oas_tags - pet
+@ oas_summary - Uploads an image.
 @ description - Upload image of the pet.
 proc UploadFile = UploadFileInput -> UploadFileOutput throws UploadFileError
 
@@ -269,21 +269,21 @@ struct UploadFileInput {
 }
 
 oneof UploadFileOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - successful operation
   ApiResponse,
 }
 
 oneof UploadFileError {
-  @ status - 400
+  @ oas_status - 400
   @ description - No file uploaded
   void,
 
-  @ status - 404
+  @ oas_status - 404
   @ description - Pet not found
   void,
 
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }

--- a/example-schemas/swagger-petstore/generated/petstore/store.bdl
+++ b/example-schemas/swagger-petstore/generated/petstore/store.bdl
@@ -3,53 +3,53 @@
 import swagger.petstore.entity { Order }
 
 @ http - GET /store/inventory
-@ security - - api_key: []
-@ tags - store
-@ summary - Returns pet inventories by status.
+@ oas_security - - api_key: []
+@ oas_tags - store
+@ oas_summary - Returns pet inventories by status.
 @ description - Returns a map of status codes to quantities.
 proc GetInventory = void -> GetInventoryOutput throws GetInventoryError
 
 oneof GetInventoryOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - successful operation
   int32[string],
 }
 
 oneof GetInventoryError {
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }
 
 @ http - POST /store/order
-@ tags - store
-@ summary - Place an order for a pet.
+@ oas_tags - store
+@ oas_summary - Place an order for a pet.
 @ description - Place a new order in the store.
 proc PlaceOrder = Order -> PlaceOrderOutput throws PlaceOrderError
 
 oneof PlaceOrderOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - successful operation
   Order,
 }
 
 oneof PlaceOrderError {
-  @ status - 400
+  @ oas_status - 400
   @ description - Invalid input
   void,
 
-  @ status - 422
+  @ oas_status - 422
   @ description - Validation exception
   void,
 
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }
 
 @ http - GET /store/order/{orderId}
-@ tags - store
-@ summary - Find purchase order by ID.
+@ oas_tags - store
+@ oas_summary - Find purchase order by ID.
 @ description - For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.
 proc GetOrderById =
   GetOrderByIdInput ->
@@ -62,28 +62,28 @@ struct GetOrderByIdInput {
 }
 
 oneof GetOrderByIdOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - successful operation
   Order,
 }
 
 oneof GetOrderByIdError {
-  @ status - 400
+  @ oas_status - 400
   @ description - Invalid ID supplied
   void,
 
-  @ status - 404
+  @ oas_status - 404
   @ description - Order not found
   void,
 
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }
 
 @ http - DELETE /store/order/{orderId}
-@ tags - store
-@ summary - Delete purchase order by identifier.
+@ oas_tags - store
+@ oas_summary - Delete purchase order by identifier.
 @ description - For valid response try integer IDs with value < 1000. Anything above 1000 or non-integers will generate API errors.
 proc DeleteOrder = DeleteOrderInput -> DeleteOrderOutput throws DeleteOrderError
 
@@ -94,21 +94,21 @@ struct DeleteOrderInput {
 }
 
 oneof DeleteOrderOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - order deleted
   void,
 }
 
 oneof DeleteOrderError {
-  @ status - 400
+  @ oas_status - 400
   @ description - Invalid ID supplied
   void,
 
-  @ status - 404
+  @ oas_status - 404
   @ description - Order not found
   void,
 
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }

--- a/example-schemas/swagger-petstore/generated/petstore/user.bdl
+++ b/example-schemas/swagger-petstore/generated/petstore/user.bdl
@@ -3,46 +3,46 @@
 import swagger.petstore.entity { User }
 
 @ http - POST /user
-@ tags - user
-@ summary - Create user.
+@ oas_tags - user
+@ oas_summary - Create user.
 @ description - This can only be done by the logged in user.
 proc CreateUser = User -> CreateUserOutput throws CreateUserError
 
 oneof CreateUserOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - successful operation
   User,
 }
 
 oneof CreateUserError {
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }
 
 @ http - POST /user/createWithList
-@ tags - user
-@ summary - Creates list of users with given input array.
+@ oas_tags - user
+@ oas_summary - Creates list of users with given input array.
 @ description - Creates list of users with given input array.
 proc CreateUsersWithListInput =
   User[] ->
   CreateUsersWithListInputOutput throws CreateUsersWithListInputError
 
 oneof CreateUsersWithListInputOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - Successful operation
   User,
 }
 
 oneof CreateUsersWithListInputError {
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }
 
 @ http - GET /user/login
-@ tags - user
-@ summary - Logs user into the system.
+@ oas_tags - user
+@ oas_summary - Logs user into the system.
 @ description - Log into the system.
 proc LoginUser = LoginUserInput -> LoginUserOutput throws LoginUserError
 
@@ -57,44 +57,44 @@ struct LoginUserInput {
 }
 
 oneof LoginUserOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - successful operation
   string,
 }
 
 oneof LoginUserError {
-  @ status - 400
+  @ oas_status - 400
   @ description - Invalid username/password supplied
   void,
 
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }
 
 @ http - GET /user/logout
-@ tags - user
-@ summary - Logs out current logged in user session.
+@ oas_tags - user
+@ oas_summary - Logs out current logged in user session.
 @ description - Log user out of the system.
 proc LogoutUser = LogoutUserInput -> LogoutUserOutput throws LogoutUserError
 
 struct LogoutUserInput {}
 
 oneof LogoutUserOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - successful operation
   void,
 }
 
 oneof LogoutUserError {
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }
 
 @ http - GET /user/{username}
-@ tags - user
-@ summary - Get user by user name.
+@ oas_tags - user
+@ oas_summary - Get user by user name.
 @ description - Get user detail based on username.
 proc GetUserByName =
   GetUserByNameInput ->
@@ -107,28 +107,28 @@ struct GetUserByNameInput {
 }
 
 oneof GetUserByNameOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - successful operation
   User,
 }
 
 oneof GetUserByNameError {
-  @ status - 400
+  @ oas_status - 400
   @ description - Invalid username supplied
   void,
 
-  @ status - 404
+  @ oas_status - 404
   @ description - User not found
   void,
 
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }
 
 @ http - PUT /user/{username}
-@ tags - user
-@ summary - Update user resource.
+@ oas_tags - user
+@ oas_summary - Update user resource.
 @ description - This can only be done by the logged in user.
 proc UpdateUser = UpdateUserInput -> UpdateUserOutput throws UpdateUserError
 
@@ -139,9 +139,6 @@ struct UpdateUserInput {
 
   @ example - 10
   id?: int64,
-
-  @ example - "theUser"
-  username?: string,
 
   @ example - "John"
   firstName?: string,
@@ -164,28 +161,28 @@ struct UpdateUserInput {
 }
 
 oneof UpdateUserOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - successful operation
   void,
 }
 
 oneof UpdateUserError {
-  @ status - 400
+  @ oas_status - 400
   @ description - bad request
   void,
 
-  @ status - 404
+  @ oas_status - 404
   @ description - user not found
   void,
 
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }
 
 @ http - DELETE /user/{username}
-@ tags - user
-@ summary - Delete user resource.
+@ oas_tags - user
+@ oas_summary - Delete user resource.
 @ description - This can only be done by the logged in user.
 proc DeleteUser = DeleteUserInput -> DeleteUserOutput throws DeleteUserError
 
@@ -196,21 +193,21 @@ struct DeleteUserInput {
 }
 
 oneof DeleteUserOutput {
-  @ status - 200
+  @ oas_status - 200
   @ description - User deleted
   void,
 }
 
 oneof DeleteUserError {
-  @ status - 400
+  @ oas_status - 400
   @ description - Invalid username supplied
   void,
 
-  @ status - 404
+  @ oas_status - 404
   @ description - User not found
   void,
 
-  @ status - default
+  @ oas_status - default
   @ description - Unexpected error
   void,
 }

--- a/standards/conventional.yaml
+++ b/standards/conventional.yaml
@@ -40,6 +40,10 @@ attributes:
       description: |-
         Provides an example value for this field.
         Used for documentation and testing purposes.
+    - key: oas_format
+      description: |-
+        Preserves the original OpenAPI string format metadata.
+        Example: "date-time", "date", "uuid", "email"
     - key: in
       description: |-
         Specifies the parameter location in requests.
@@ -50,14 +54,28 @@ attributes:
   bdl.oneof:
     - key: discriminator
       description: TODO
+  bdl.oneof.item:
+    - key: oas_status
+      description: |-
+        HTTP status code string as provided by the OpenAPI response map.
+        Example: "200", "400", "404", "500", "default"
   bdl.union.item:
     - key: status
       description: |-
         HTTP status code for this response variant.
-        Example: "404", "400", "500"
+        Example: "200", "400", "404", "500", "default"
   bdl.proc:
     - key: http
       description: |-
         Specifies the HTTP method and endpoint path for this procedure.
         Format: "{METHOD} {path}"
         Example: "GET /bdl/standards/{standardId}"
+    - key: oas_security
+      description: |-
+        OpenAPI security requirement object serialized as YAML.
+    - key: oas_tags
+      description: |-
+        Comma-separated OpenAPI operation tags.
+    - key: oas_summary
+      description: |-
+        OpenAPI operation summary text.


### PR DESCRIPTION
## Summary
- regenerate `example-schemas/swagger-petstore` outputs under conventional standard and remove legacy `swagger-petstore` standard headers
- update `convert-petstore.ts` to emit OpenAPI metadata as prefixed attributes (`oas_security`, `oas_tags`, `oas_summary`, `oas_status`) and keep `description` on global standard
- map OpenAPI `date-time` to `string` with `@ oas_format - date-time`, and deduplicate same-name input fields by preferring required fields over optional ones
- extend `standards/conventional.yaml` with `oas_format`, `oas_security`, `oas_tags`, `oas_summary`, and `bdl.oneof.item` `oas_status` definitions