### PR TITLE
Document enum value and oneof discriminator attributes in conventional standard

### DIFF
--- a/standards/conventional.yaml
+++ b/standards/conventional.yaml
@@ -50,10 +50,14 @@ attributes:
         Common values: "path", "query", "header", "body"
   bdl.enum.item:
     - key: value
-      description: TODO
+      description: |-
+        Explicit serialized value of this enum item.
+        If omitted, the enum item name is used as the value.
   bdl.oneof:
     - key: discriminator
-      description: TODO
+      description: |-
+        Field name used to distinguish oneof variants during serialization.
+        Example: "type", "kind"
   bdl.oneof.item:
     - key: oas_status
       description: |-


### PR DESCRIPTION
## Summary
- replace TODO placeholders for `bdl.enum.item` `value` and `bdl.oneof` `discriminator` in `standards/conventional.yaml`
- explain enum item `value` semantics (explicit serialized value and fallback to item name)
- clarify oneof `discriminator` usage as the variant-discriminating field name with examples