### PR TITLE
feat: add import sorting to bdl formatter

### DIFF
--- a/bdl-ts/src/formatter/bdl.ts
+++ b/bdl-ts/src/formatter/bdl.ts
@@ -138,10 +138,9 @@ export function formatBdl(
               gap = stripLeadingLineBreaks(gap);
             }
             if (result.length > 0) {
-              if (runIndex === 0 && hasAnchoredGap && gap.length === 0) {
-                // anchored gap already established separation before first sorted unit
-              } else 
-              if (gap.length === 0) result += "\n";
+              if (runIndex === 0 && hasAnchoredGap) {
+                result += gap;
+              } else if (gap.length === 0) result += "\n";
               else if (!gap.startsWith("\n") && !gap.startsWith("\r\n")) result += "\n" + gap;
               else result += gap;
             } else {

--- a/bdl-ts/src/formatter/bdl/bdl.test.ts
+++ b/bdl-ts/src/formatter/bdl/bdl.test.ts
@@ -1462,6 +1462,24 @@ Deno.test("import sort: inline trailing anchor does not pin first import comment
   );
 });
 
+Deno.test("import sort: anchored first-run gap does not add extra blank line", () => {
+  const source = [
+    "struct User {} // keep with struct",
+    "// keep with a",
+    "import a.pkg { A }",
+    "import z.pkg { Z }",
+  ].join("\n");
+  assertEquals(
+    formatBdl(source, { finalNewline: false }),
+    [
+      "struct User {} // keep with struct",
+      "// keep with a",
+      "import a.pkg { A }",
+      "import z.pkg { Z }",
+    ].join("\n"),
+  );
+});
+
 Deno.test("import sort: url in leading comment does not trigger inline anchor", () => {
   const source = [
     "// docs https://example.com/x",


### PR DESCRIPTION
## Summary
- Add module-level import sorting in `formatBdl`, including grouped sorting of `Attribute* + Import` units so attributes and nearby leading comments move with their import.
- Add import-item sorting inside `import { ... }` blocks by name/alias, while preserving existing behavior by skipping item sorting when comment trivia or `bdlc-fmt-ignore` directives are present.
- Add comprehensive formatter tests for import sorting behavior and integration with existing formatting/ignore flows (module imports, items, attributes, comments, mixed statements, and multiline imports).

## Testing
- `deno test -A src/formatter/bdl/bdl.test.ts`
- `deno test -A cli/bdlc.test.ts`