### PR TITLE
feat: add builtin standards support and VSCode virtual docs

### DIFF
--- a/bdl-ts/cli/reflection.ts
+++ b/bdl-ts/cli/reflection.ts
@@ -3,7 +3,7 @@ import { Hono } from "@hono/hono";
 import { buildIrWithConfigObject } from "../src/io/ir.ts";
 import type { BdlConfig } from "../src/generated/config.ts";
 import type { BdlStandard } from "../src/generated/standard.ts";
-import conventionalStandard from "../src/conventional/standard.ts";
+import builtinStandards from "../src/builtin/standards.ts";
 import {
   gatherEntryModulePaths,
   getResolveModuleFileFn,
@@ -44,8 +44,8 @@ export function createReflectionServer(
   app.get("/bdl/standards/:standardId", async (c) => {
     const standardId = c.req.param("standardId");
     const standards = bdlConfig.standards || {};
-    if ((standardId === "conventional") && !("conventional" in standards)) {
-      return c.json(conventionalStandard);
+    if (standardId in builtinStandards && !(standardId in standards)) {
+      return c.json(builtinStandards[standardId]);
     }
     if (!(standardId in standards)) return c.json({ type: "NotFound" }, 404);
     const standardPath = standards[standardId];
@@ -72,7 +72,7 @@ export function createReflectionServer(
 }
 
 function listStandards(config: BdlConfig): Set<string> {
-  const standards = new Set(["conventional"]);
+  const standards = new Set(Object.keys(builtinStandards));
   for (const key of Object.keys(config.standards || {})) standards.add(key);
   return standards;
 }

--- a/bdl-ts/deno.json
+++ b/bdl-ts/deno.json
@@ -26,8 +26,9 @@
     "./parser": "./src/parser/bdl/ast-parser.ts",
     "./parser/cst": "./src/parser/bdl/cst-parser.ts",
     "./formatter/bdl": "./src/formatter/bdl.ts",
-    "./standards/conventional": "./src/conventional/standard.ts",
-    "./standards/global": "./src/global/standard.ts"
+    "./builtin/standards": "./src/builtin/standards.ts",
+    "./builtin/standards/conventional": "./src/builtin/standards/conventional.ts",
+    "./builtin/standards/global": "./src/builtin/standards/global.ts"
   },
   "imports": {
     "@cliffy/command": "jsr:@cliffy/command@1.0.0-rc.7",

--- a/bdl-ts/src/builtin/standards.ts
+++ b/bdl-ts/src/builtin/standards.ts
@@ -1,0 +1,16 @@
+import type { BdlStandard } from "../generated/standard.ts";
+import conventionalStandard, {
+  yamlText as conventionalYaml,
+} from "./standards/conventional.ts";
+import globalStandard, { yamlText as globalYaml } from "./standards/global.ts";
+
+const standards: Record<string, BdlStandard> = {
+  conventional: conventionalStandard,
+  global: globalStandard,
+};
+export default standards;
+
+export const builtinStandardYamls: Record<string, string> = {
+  conventional: conventionalYaml,
+  global: globalYaml,
+};

--- a/bdl-ts/src/builtin/standards/conventional.ts
+++ b/bdl-ts/src/builtin/standards/conventional.ts
@@ -1,0 +1,10 @@
+import type { BdlStandard } from "../../generated/standard.ts";
+import standard from "../../generated/json/conventional.json" with {
+  type: "json",
+};
+export default standard as unknown as BdlStandard;
+
+import yamlText from "../../../../standards/conventional.yaml" with {
+  type: "text",
+};
+export { yamlText };

--- a/bdl-ts/src/builtin/standards/global.ts
+++ b/bdl-ts/src/builtin/standards/global.ts
@@ -1,0 +1,10 @@
+import type { BdlStandard } from "../../generated/standard.ts";
+import standard from "../../generated/json/global.json" with {
+  type: "json",
+};
+export default standard as unknown as BdlStandard;
+
+import yamlText from "../../../../standards/global.yaml" with {
+  type: "text",
+};
+export { yamlText };

--- a/bdl-ts/src/conventional/standard.ts
+++ b/bdl-ts/src/conventional/standard.ts
@@ -1,6 +1,0 @@
-import type { BdlStandard } from "../generated/standard.ts";
-import standard from "../generated/json/conventional.json" with {
-  type: "json",
-};
-
-export default standard as unknown as BdlStandard;

--- a/bdl-ts/src/generated/json/conventional.json
+++ b/bdl-ts/src/generated/json/conventional.json
@@ -50,6 +50,10 @@
         "description": "Provides an example value for this field.\nUsed for documentation and testing purposes."
       },
       {
+        "key": "oas_format",
+        "description": "Preserves the original OpenAPI string format metadata.\nExample: \"date-time\", \"date\", \"uuid\", \"email\""
+      },
+      {
         "key": "in",
         "description": "Specifies the parameter location in requests.\nCommon values: \"path\", \"query\", \"header\", \"body\""
       }
@@ -57,25 +61,43 @@
     "bdl.enum.item": [
       {
         "key": "value",
-        "description": "TODO"
+        "description": "Explicit serialized value of this enum item.\nIf omitted, the enum item name is used as the value."
       }
     ],
     "bdl.oneof": [
       {
         "key": "discriminator",
-        "description": "TODO"
+        "description": "Field name used to distinguish oneof variants during serialization.\nExample: \"type\", \"kind\""
+      }
+    ],
+    "bdl.oneof.item": [
+      {
+        "key": "oas_status",
+        "description": "HTTP status code string as provided by the OpenAPI response map.\nExample: \"200\", \"400\", \"404\", \"500\", \"default\""
       }
     ],
     "bdl.union.item": [
       {
         "key": "status",
-        "description": "HTTP status code for this response variant.\nExample: \"404\", \"400\", \"500\""
+        "description": "HTTP status code for this response variant.\nExample: \"200\", \"400\", \"404\", \"500\", \"default\""
       }
     ],
     "bdl.proc": [
       {
         "key": "http",
         "description": "Specifies the HTTP method and endpoint path for this procedure.\nFormat: \"{METHOD} {path}\"\nExample: \"GET /bdl/standards/{standardId}\""
+      },
+      {
+        "key": "oas_security",
+        "description": "OpenAPI security requirement object serialized as YAML."
+      },
+      {
+        "key": "oas_tags",
+        "description": "Comma-separated OpenAPI operation tags."
+      },
+      {
+        "key": "oas_summary",
+        "description": "OpenAPI operation summary text."
       }
     ]
   }

--- a/bdl-ts/src/global/standard.ts
+++ b/bdl-ts/src/global/standard.ts
@@ -1,6 +1,0 @@
-import type { BdlStandard } from "../generated/standard.ts";
-import standard from "../generated/json/global.json" with {
-  type: "json",
-};
-
-export default standard as unknown as BdlStandard;

--- a/bdl-ts/src/linter/bdl.test.ts
+++ b/bdl-ts/src/linter/bdl.test.ts
@@ -1,5 +1,5 @@
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
-import conventionalStandard from "../conventional/standard.ts";
+import conventionalStandard from "../builtin/standards/conventional.ts";
 import { lintBdl, type LintBdlResult } from "./bdl.ts";
 
 async function lintBdlFinal(config: Parameters<typeof lintBdl>[0]) {

--- a/bdl-vscode/scripts/build.ts
+++ b/bdl-vscode/scripts/build.ts
@@ -8,6 +8,7 @@ const denoBundleCommand = new Deno.Command(Deno.execPath(), {
     "--format", "cjs",
     "--platform", "browser",
     "--external", "vscode",
+    "--unstable-raw-imports",
     "-o", "dist/main.js",
     "src/main.ts",
   ],

--- a/bdl-vscode/src/context.ts
+++ b/bdl-vscode/src/context.ts
@@ -5,6 +5,7 @@ import { getAttributeContent, slice } from "@disjukr/bdl/ast/misc";
 import { type BdlConfig } from "@disjukr/bdl/io/config";
 import { type BdlStandard } from "@disjukr/bdl/io/standard";
 import parseBdl from "@disjukr/bdl/parser";
+import builtinStandards from "@disjukr/bdl/builtin/standards";
 
 export class BdlShortTermContext {
   #workspaceFolder: vscode.WorkspaceFolder | undefined;
@@ -65,8 +66,13 @@ export class BdlShortTermContext {
       const standardId = this.entryDocContext.standardId;
       if (!standardId) return;
       const bdlConfig = await this.getBdlConfig();
-      if (!this.#loadBdlConfigResult?.success) return;
-      if (!bdlConfig?.standards?.[standardId]) return;
+      if (
+        !(this.#loadBdlConfigResult?.success) ||
+        !(bdlConfig?.standards?.[standardId])
+      ) {
+        if (standardId in builtinStandards) return builtinStandards[standardId];
+        return;
+      }
       const standardPath = bdlConfig.standards[standardId];
       const { configDirectory } = this.#loadBdlConfigResult;
       const standardUri = vscode.Uri.joinPath(configDirectory, standardPath);

--- a/bdl-vscode/src/definitions.ts
+++ b/bdl-vscode/src/definitions.ts
@@ -20,6 +20,7 @@ import {
   pickImportStatementByPath,
   pickType,
 } from "@disjukr/bdl/ast/span-picker";
+import builtinStandards from "@disjukr/bdl/builtin/standards";
 import type { AttributeSlot } from "@disjukr/bdl/io/standard";
 import { BdlShortTermContext, BdlShortTermDocumentContext } from "./context.ts";
 import { getImportPathInfo, spanToRange } from "./misc.ts";
@@ -95,7 +96,15 @@ async function findStandardTargetDocument(
   const standardId = docContext.standardId;
   if (!standardId) return;
   const bdlConfig = await docContext.context.getBdlConfig();
-  if (!bdlConfig?.standards?.[standardId]) return;
+  if (!bdlConfig?.standards?.[standardId]) {
+    if (standardId in builtinStandards) {
+      return await vscode.workspace.openTextDocument(vscode.Uri.from({
+        scheme: "bdl-builtin-standard",
+        path: `/${standardId}.yaml`,
+      }));
+    }
+    return;
+  }
   const configDirectory = await docContext.context.getBdlConfigDirectory();
   if (!configDirectory) return;
   const targetUri = vscode.Uri.joinPath(

--- a/bdl-vscode/src/main.ts
+++ b/bdl-vscode/src/main.ts
@@ -2,9 +2,11 @@ import * as vscode from "vscode";
 import { initDefinitions } from "./definitions.ts";
 import { initDiagnostics } from "./diagnostics.ts";
 import { initFormatter } from "./formatter.ts";
+import { initVirtualDocuments } from "./virtual-documents.ts";
 
 export function activate(context: vscode.ExtensionContext) {
   initDefinitions(context);
   initDiagnostics(context);
   initFormatter(context);
+  initVirtualDocuments(context);
 }

--- a/bdl-vscode/src/virtual-documents.ts
+++ b/bdl-vscode/src/virtual-documents.ts
@@ -1,0 +1,28 @@
+import * as vscode from "vscode";
+import builtinStandards, {
+  builtinStandardYamls,
+} from "@disjukr/bdl/builtin/standards";
+
+export function initVirtualDocuments(
+  extensionContext: vscode.ExtensionContext,
+) {
+  extensionContext.subscriptions.push(
+    vscode.workspace.registerTextDocumentContentProvider(
+      "bdl-builtin-standard",
+      new BdlBuiltinStandardContentProvider(extensionContext),
+    ),
+  );
+}
+
+class BdlBuiltinStandardContentProvider
+  implements vscode.TextDocumentContentProvider {
+  constructor(public extensionContext: vscode.ExtensionContext) {}
+  provideTextDocumentContent(uri: vscode.Uri): string | undefined {
+    const standardId = uri.path.slice(1).replace(/\.(json|yaml)$/, "");
+    if (!(standardId in builtinStandards)) return;
+    if (uri.path.endsWith(".yaml")) return builtinStandardYamls[standardId];
+    if (uri.path.endsWith(".json")) {
+      return JSON.stringify(builtinStandards[standardId], null, 2) + "\n";
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce `bdl-ts` builtin standards module exports (JSON + YAML text) and update consumers to use centralized builtin standard sources.
- Update linter and reflection/server standard resolution to recognize builtin standards alongside configured standards.
- Add VSCode virtual document support for builtin standards and wire it into definition/context flows so builtin standard navigation works without local files.

## Testing
- Not run in this step (uses already staged local changes)