### PR TITLE
fix: correct RoughJsonKeyValue naming typo

### DIFF
--- a/bdl-ts/runtime/src/json/rough-json.ts
+++ b/bdl-ts/runtime/src/json/rough-json.ts
@@ -38,10 +38,10 @@ export interface RoughArray {
 
 export interface RoughObject {
   type: "object";
-  items: RouthJsonKeyValue[];
+  items: RoughJsonKeyValue[];
 }
 
-export interface RouthJsonKeyValue {
+export interface RoughJsonKeyValue {
   key: RoughString;
   value: RoughJson;
 }
@@ -160,7 +160,7 @@ function expectArray(ctx: Context): RoughArray {
 function expectObject(ctx: Context): RoughObject {
   ctx.pos += 1;
   skipWs(ctx);
-  const items: RouthJsonKeyValue[] = [];
+  const items: RoughJsonKeyValue[] = [];
   while (ctx.text[ctx.pos] !== "}") {
     const key = expectString(ctx);
     skipWs(ctx);


### PR DESCRIPTION
## Summary
- Rename misspelled `RouthJsonKeyValue` to `RoughJsonKeyValue` in `rough-json` runtime types.
- Update object item typing usage to reference the corrected type name.
- Keep behavior unchanged; this is a type-name consistency and readability fix.