### PR TITLE
Normalize one-line attribute parsing

### DIFF
--- a/bdl-ts/src/ast/misc.ts
+++ b/bdl-ts/src/ast/misc.ts
@@ -41,7 +41,7 @@ export function getAttributeContent(
 ): string {
   if (!attribute.content) return "";
   const content = slice(text, attribute.content);
-  if (content.startsWith("-")) return content.replace(/^- ?/, "");
+  if (content.startsWith("-")) return content.replace(/^- ?/, "").trim();
   return content
     .split("\n")
     .map((line) => line.replace(/^\s*\|\x20?/, ""))

--- a/bdl-ts/src/linter/bdl.test.ts
+++ b/bdl-ts/src/linter/bdl.test.ts
@@ -360,3 +360,35 @@ Deno.test("lint directives: disable-line works with CRLF input", async () => {
   });
   assertEquals(result.diagnostics.length, 0);
 });
+
+Deno.test("lintBdl recognizes builtin standard with CRLF input", async () => {
+  const result = await lintBdlFinal({
+    text: [
+      "# standard - conventional",
+      "struct User {",
+      "  id: string,",
+      "}",
+      "",
+    ].join("\r\n"),
+    standard: conventionalStandard,
+  });
+  const codes = result.diagnostics.map((diag) => diag.code);
+  assert(!codes.includes("bdl/unknown-standard"));
+  assert(!codes.includes("bdl/unknown-type"));
+});
+
+Deno.test("lintBdl trims one-line attribute content", async () => {
+  const result = await lintBdlFinal({
+    text: [
+      "# standard -   conventional   ",
+      "struct User {",
+      "  id: string,",
+      "}",
+      "",
+    ].join("\n"),
+    standard: conventionalStandard,
+  });
+  const codes = result.diagnostics.map((diag) => diag.code);
+  assert(!codes.includes("bdl/unknown-standard"));
+  assert(!codes.includes("bdl/unknown-type"));
+});

--- a/bdl-vscode/package.json
+++ b/bdl-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "bdl",
   "displayName": "BDL - Bridge Definition Language",
   "description": "BDL Language Support",
-  "version": "0.0.13",
+  "version": "0.0.0",
   "publisher": "disjukr",
   "license": "(MIT OR Apache-2.0)",
   "repository": {


### PR DESCRIPTION
## Summary
- trim one-line attribute content after removing the -  prefix
- fix CRLF cases where # standard - conventional could be parsed with a trailing carriage return
- add linter tests for CRLF builtin standard resolution and one-line whitespace normalization
- set the local dl-vscode package version to 