### PR TITLE
Remove raw-import dependency from builtin standards

### DIFF
--- a/bdl-ts/cli/bdlc.test.ts
+++ b/bdl-ts/cli/bdlc.test.ts
@@ -10,7 +10,7 @@ interface CommandResult {
 async function runBdlc(args: string[], cwd?: string): Promise<CommandResult> {
   const scriptPath = fromFileUrl(new URL("./bdlc.ts", import.meta.url));
   const command = new Deno.Command(Deno.execPath(), {
-    args: ["run", "-A", "--unstable-raw-imports", scriptPath, ...args],
+    args: ["run", "-A", scriptPath, ...args],
     cwd,
     stdout: "piped",
     stderr: "piped",

--- a/bdl-ts/cli/bdlc.ts
+++ b/bdl-ts/cli/bdlc.ts
@@ -9,7 +9,6 @@ import parseBdl from "../src/parser/bdl/ast-parser.ts";
 import { formatBdl } from "../src/formatter/bdl.ts";
 import { generateOas } from "../src/generator/openapi/oas-30-generator.ts";
 import { generateTs } from "../src/generator/ts/ts-generator.ts";
-import { createReflectionServer } from "./reflection.ts";
 
 const astCommand = new Command()
   .description("Parse single BDL file and print AST")
@@ -78,6 +77,7 @@ const reflectionCommand = new Command()
   )
   .action(async (options) => {
     const { bdlConfig, configDirectory } = await loadBdlConfig(options.config);
+    const { createReflectionServer } = await import("./reflection.ts");
     const app = createReflectionServer(bdlConfig, configDirectory);
     Deno.serve({ port: options.port }, app.fetch);
   });


### PR DESCRIPTION
## Summary
- generate TypeScript modules for builtin standard YAML text and load those instead of raw text imports
- remove the now-unnecessary raw-import flags from the CLI Docker build and VS Code extension bundle script
- document that the CLI and build scripts now work with plain deno run/compile

## Testing
- deno test -A bdl-ts/cli/bdlc.test.ts
- deno run -A bdl-ts/cli/bdlc.ts --help
- deno compile -A -o tmp/bdlc-rawless.exe bdl-ts/cli/bdlc.ts
- deno bundle --format cjs --platform browser --external vscode -o tmp/bdl-vscode-main.cjs bdl-vscode/src/main.ts

Fixes #53