### PR TITLE
Align OpenAPI generator with conventional attrs

### DIFF
--- a/bdl-ts/src/generated/json/conventional.json
+++ b/bdl-ts/src/generated/json/conventional.json
@@ -78,12 +78,20 @@
       {
         "key": "example",
         "description": "Provides an example value for this response variant.\nUsed for generated OpenAPI response examples."
+      },
+      {
+        "key": "oas_headers",
+        "description": "OpenAPI response header map serialized as YAML.\nPreserves response-specific header definitions for OpenAPI round-tripping."
       }
     ],
     "bdl.union.item": [
       {
         "key": "status",
         "description": "HTTP status code for this response variant.\nExample: \"200\", \"400\", \"404\", \"500\", \"default\""
+      },
+      {
+        "key": "oas_headers",
+        "description": "OpenAPI response header map serialized as YAML.\nPreserves response-specific header definitions for OpenAPI round-tripping."
       }
     ],
     "bdl.proc": [

--- a/bdl-ts/src/generated/json/conventional.json
+++ b/bdl-ts/src/generated/json/conventional.json
@@ -74,6 +74,10 @@
       {
         "key": "oas_status",
         "description": "HTTP status code string as provided by the OpenAPI response map.\nExample: \"200\", \"400\", \"404\", \"500\", \"default\""
+      },
+      {
+        "key": "example",
+        "description": "Provides an example value for this response variant.\nUsed for generated OpenAPI response examples."
       }
     ],
     "bdl.union.item": [

--- a/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
@@ -36,7 +36,7 @@ Deno.test("generateOas reads conventional oas_* proc and field attributes", () =
           summary: "legacy summary",
           oas_summary: "Create user",
           oas_tags: "users, admin ",
-          oas_security: "- bearerAuth: []",
+          oas_security: "bearerAuth: []",
         },
         name: "CreateUser",
         inputType: {
@@ -76,6 +76,61 @@ Deno.test("generateOas reads conventional oas_* proc and field attributes", () =
     properties: {
       email: {
         type: "string",
+        description: "User email address",
+        format: "email",
+      },
+    },
+  });
+});
+
+Deno.test("generateOas keeps field metadata when oas_format is applied to refs", () => {
+  const ir: BdlIr = {
+    modules: {
+      "pkg.api": {
+        attributes: {},
+        defPaths: ["pkg.api.Email", "pkg.api.User"],
+        imports: [],
+      },
+    },
+    defs: {
+      "pkg.api.Email": {
+        type: "Custom",
+        attributes: {},
+        name: "Email",
+        originalType: {
+          type: "Plain",
+          valueTypePath: "string",
+        },
+      },
+      "pkg.api.User": {
+        type: "Struct",
+        attributes: {},
+        name: "User",
+        fields: [{
+          attributes: {
+            description: "User email address",
+            oas_format: "email",
+          },
+          name: "email",
+          fieldType: {
+            type: "Plain",
+            valueTypePath: "pkg.api.Email",
+          },
+          optional: false,
+        }],
+      },
+    },
+  };
+
+  const result = generateOas({ ir }).schema;
+  const userSchema = result.components?.schemas?.User;
+
+  assertEquals(userSchema, {
+    type: "object",
+    required: ["email"],
+    properties: {
+      email: {
+        allOf: [{ $ref: "#/components/schemas/Email" }],
         description: "User email address",
         format: "email",
       },

--- a/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
@@ -33,7 +33,6 @@ Deno.test("generateOas reads conventional oas_* proc and field attributes", () =
         type: "Proc",
         attributes: {
           http: "POST /users",
-          summary: "legacy summary",
           oas_summary: "Create user",
           oas_tags: "users, admin ",
           oas_security: "bearerAuth: []",
@@ -138,7 +137,148 @@ Deno.test("generateOas keeps field metadata when oas_format is applied to refs",
   });
 });
 
-Deno.test("generateOas keeps legacy summary fallback for existing schemas", () => {
+Deno.test("generateOas emits responses from oneof oas_status metadata", () => {
+  const ir: BdlIr = {
+    modules: {
+      "pkg.api": {
+        attributes: {},
+        defPaths: [
+          "pkg.api.OkResponse",
+          "pkg.api.NotFoundResponse",
+          "pkg.api.GetUserOutput",
+          "pkg.api.GetUserError",
+          "pkg.api.GetUser",
+        ],
+        imports: [],
+      },
+    },
+    defs: {
+      "pkg.api.OkResponse": {
+        type: "Struct",
+        attributes: {},
+        name: "OkResponse",
+        fields: [{
+          attributes: {},
+          name: "id",
+          fieldType: {
+            type: "Plain",
+            valueTypePath: "string",
+          },
+          optional: false,
+        }],
+      },
+      "pkg.api.NotFoundResponse": {
+        type: "Struct",
+        attributes: {},
+        name: "NotFoundResponse",
+        fields: [{
+          attributes: {},
+          name: "message",
+          fieldType: {
+            type: "Plain",
+            valueTypePath: "string",
+          },
+          optional: false,
+        }],
+      },
+      "pkg.api.GetUserOutput": {
+        type: "Oneof",
+        attributes: {},
+        name: "GetUserOutput",
+        items: [{
+          attributes: {
+            oas_status: "200",
+            description: "User loaded",
+          },
+          itemType: {
+            type: "Plain",
+            valueTypePath: "pkg.api.OkResponse",
+          },
+        }],
+      },
+      "pkg.api.GetUserError": {
+        type: "Oneof",
+        attributes: {},
+        name: "GetUserError",
+        items: [{
+          attributes: {
+            oas_status: "404",
+            description: "User not found",
+          },
+          itemType: {
+            type: "Plain",
+            valueTypePath: "pkg.api.NotFoundResponse",
+          },
+        }, {
+          attributes: {
+            oas_status: "default",
+            description: "Unexpected failure",
+            example: '{"message":"boom"}',
+          },
+          itemType: {
+            type: "Plain",
+            valueTypePath: "pkg.api.NotFoundResponse",
+          },
+        }],
+      },
+      "pkg.api.GetUser": {
+        type: "Proc",
+        attributes: {
+          http: "GET /users/{id}",
+          oas_summary: "Get user",
+        },
+        name: "GetUser",
+        inputType: {
+          type: "Plain",
+          valueTypePath: "void",
+        },
+        outputType: {
+          type: "Plain",
+          valueTypePath: "pkg.api.GetUserOutput",
+        },
+        errorType: {
+          type: "Plain",
+          valueTypePath: "pkg.api.GetUserError",
+        },
+      },
+    },
+  };
+
+  const result = generateOas({ ir }).schema;
+  const userPath = result.paths?.["/users/{id}"];
+  if (!userPath || "$ref" in userPath) {
+    throw new Error("expected /users/{id} path item");
+  }
+  assertEquals(userPath.get?.responses, {
+    "200": {
+      description: "User loaded",
+      content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/OkResponse" },
+        },
+      },
+    },
+    "404": {
+      description: "User not found",
+      content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/NotFoundResponse" },
+        },
+      },
+    },
+    default: {
+      description: "Unexpected failure",
+      content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/NotFoundResponse" },
+          example: { message: "boom" },
+        },
+      },
+    },
+  });
+});
+
+Deno.test("generateOas emits a default success response for plain outputs", () => {
   const ir: BdlIr = {
     modules: {
       "pkg.api": {
@@ -152,7 +292,7 @@ Deno.test("generateOas keeps legacy summary fallback for existing schemas", () =
         type: "Proc",
         attributes: {
           http: "GET /ping",
-          summary: "Ping",
+          oas_summary: "Ping",
         },
         name: "Ping",
         inputType: {
@@ -172,5 +312,44 @@ Deno.test("generateOas keeps legacy summary fallback for existing schemas", () =
   if (!pingPath || "$ref" in pingPath) {
     throw new Error("expected /ping path item");
   }
-  assertEquals(pingPath.get?.summary, "Ping");
+  assertEquals(pingPath.get?.responses, {
+    "200": { description: "Successful response" },
+  });
+});
+
+Deno.test("generateOas ignores legacy proc summary attributes", () => {
+  const ir: BdlIr = {
+    modules: {
+      "pkg.api": {
+        attributes: {},
+        defPaths: ["pkg.api.LegacySummary"],
+        imports: [],
+      },
+    },
+    defs: {
+      "pkg.api.LegacySummary": {
+        type: "Proc",
+        attributes: {
+          http: "GET /legacy-summary",
+          summary: "Legacy summary",
+        },
+        name: "LegacySummary",
+        inputType: {
+          type: "Plain",
+          valueTypePath: "void",
+        },
+        outputType: {
+          type: "Plain",
+          valueTypePath: "void",
+        },
+      },
+    },
+  };
+
+  const result = generateOas({ ir }).schema;
+  const legacyPath = result.paths?.["/legacy-summary"];
+  if (!legacyPath || "$ref" in legacyPath) {
+    throw new Error("expected /legacy-summary path item");
+  }
+  assertEquals(legacyPath.get?.summary, undefined);
 });

--- a/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
@@ -1,0 +1,121 @@
+import { assertEquals } from "@std/assert";
+import type { BdlIr } from "../../generated/ir.ts";
+import { generateOas } from "./oas-30-generator.ts";
+
+Deno.test("generateOas reads conventional oas_* proc and field attributes", () => {
+  const ir: BdlIr = {
+    modules: {
+      "pkg.api": {
+        attributes: {},
+        defPaths: ["pkg.api.CreateUserInput", "pkg.api.CreateUser"],
+        imports: [],
+      },
+    },
+    defs: {
+      "pkg.api.CreateUserInput": {
+        type: "Struct",
+        attributes: {},
+        name: "CreateUserInput",
+        fields: [{
+          attributes: {
+            description: "User email address",
+            oas_format: "email",
+          },
+          name: "email",
+          fieldType: {
+            type: "Plain",
+            valueTypePath: "string",
+          },
+          optional: false,
+        }],
+      },
+      "pkg.api.CreateUser": {
+        type: "Proc",
+        attributes: {
+          http: "POST /users",
+          summary: "legacy summary",
+          oas_summary: "Create user",
+          oas_tags: "users, admin ",
+          oas_security: "- bearerAuth: []",
+        },
+        name: "CreateUser",
+        inputType: {
+          type: "Plain",
+          valueTypePath: "pkg.api.CreateUserInput",
+        },
+        outputType: {
+          type: "Plain",
+          valueTypePath: "void",
+        },
+      },
+    },
+  };
+
+  const result = generateOas({ ir }).schema;
+  const usersPath = result.paths?.["/users"];
+  if (!usersPath || "$ref" in usersPath) {
+    throw new Error("expected /users path item");
+  }
+  const operation = usersPath.post;
+  const requestBody = operation?.requestBody;
+  if (!requestBody || "$ref" in requestBody) {
+    throw new Error("expected inline request body");
+  }
+  const emailSchema = result.components?.schemas?.CreateUserInput;
+
+  assertEquals(operation?.summary, "Create user");
+  assertEquals(operation?.tags, ["users", "admin"]);
+  assertEquals(operation?.security, [{ bearerAuth: [] }]);
+  assertEquals(
+    requestBody.content?.["application/json"]?.schema,
+    { $ref: "#/components/schemas/CreateUserInput" },
+  );
+  assertEquals(emailSchema, {
+    type: "object",
+    required: ["email"],
+    properties: {
+      email: {
+        type: "string",
+        description: "User email address",
+        format: "email",
+      },
+    },
+  });
+});
+
+Deno.test("generateOas keeps legacy summary fallback for existing schemas", () => {
+  const ir: BdlIr = {
+    modules: {
+      "pkg.api": {
+        attributes: {},
+        defPaths: ["pkg.api.Ping"],
+        imports: [],
+      },
+    },
+    defs: {
+      "pkg.api.Ping": {
+        type: "Proc",
+        attributes: {
+          http: "GET /ping",
+          summary: "Ping",
+        },
+        name: "Ping",
+        inputType: {
+          type: "Plain",
+          valueTypePath: "void",
+        },
+        outputType: {
+          type: "Plain",
+          valueTypePath: "void",
+        },
+      },
+    },
+  };
+
+  const result = generateOas({ ir }).schema;
+  const pingPath = result.paths?.["/ping"];
+  if (!pingPath || "$ref" in pingPath) {
+    throw new Error("expected /ping path item");
+  }
+  assertEquals(pingPath.get?.summary, "Ping");
+});

--- a/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
@@ -278,17 +278,15 @@ Deno.test("generateOas emits responses from oneof oas_status metadata", () => {
   });
 });
 
-Deno.test("generateOas keeps legacy security and status attrs for non-conventional schemas", () => {
+Deno.test("generateOas does not synthesize descriptions for oneof responses", () => {
   const ir: BdlIr = {
     modules: {
       "pkg.api": {
         attributes: {},
         defPaths: [
           "pkg.api.OkResponse",
-          "pkg.api.UnauthorizedResponse",
-          "pkg.api.LegacyOutput",
-          "pkg.api.LegacyError",
-          "pkg.api.LegacyProc",
+          "pkg.api.GetUserOutput",
+          "pkg.api.GetUser",
         ],
         imports: [],
       },
@@ -300,21 +298,7 @@ Deno.test("generateOas keeps legacy security and status attrs for non-convention
         name: "OkResponse",
         fields: [{
           attributes: {},
-          name: "ok",
-          fieldType: {
-            type: "Plain",
-            valueTypePath: "boolean",
-          },
-          optional: false,
-        }],
-      },
-      "pkg.api.UnauthorizedResponse": {
-        type: "Struct",
-        attributes: {},
-        name: "UnauthorizedResponse",
-        fields: [{
-          attributes: {},
-          name: "message",
+          name: "id",
           fieldType: {
             type: "Plain",
             valueTypePath: "string",
@@ -322,14 +306,13 @@ Deno.test("generateOas keeps legacy security and status attrs for non-convention
           optional: false,
         }],
       },
-      "pkg.api.LegacyOutput": {
+      "pkg.api.GetUserOutput": {
         type: "Oneof",
         attributes: {},
-        name: "LegacyOutput",
+        name: "GetUserOutput",
         items: [{
           attributes: {
-            status: "201",
-            description: "Created",
+            oas_status: "200",
           },
           itemType: {
             type: "Plain",
@@ -337,8 +320,79 @@ Deno.test("generateOas keeps legacy security and status attrs for non-convention
           },
         }],
       },
+      "pkg.api.GetUser": {
+        type: "Proc",
+        attributes: {
+          http: "GET /users/{id}",
+          oas_summary: "Get user",
+        },
+        name: "GetUser",
+        inputType: {
+          type: "Plain",
+          valueTypePath: "void",
+        },
+        outputType: {
+          type: "Plain",
+          valueTypePath: "pkg.api.GetUserOutput",
+        },
+      },
+    },
+  };
+
+  const result = generateOas({ ir }).schema;
+  const userPath = result.paths?.["/users/{id}"];
+  if (!userPath || "$ref" in userPath) {
+    throw new Error("expected /users/{id} path item");
+  }
+
+  assertEquals(userPath.get?.responses, {
+    "200": {
+      content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/OkResponse" },
+        },
+      },
+    },
+  });
+});
+
+Deno.test("generateOas keeps legacy proc security attrs and reads union status attrs", () => {
+  const ir: BdlIr = {
+    modules: {
+      "pkg.api": {
+        attributes: {},
+        defPaths: [
+          "pkg.api.LegacyOutput",
+          "pkg.api.LegacyError",
+          "pkg.api.LegacyProc",
+        ],
+        imports: [],
+      },
+    },
+    defs: {
+      "pkg.api.LegacyOutput": {
+        type: "Union",
+        attributes: {},
+        name: "LegacyOutput",
+        items: [{
+          attributes: {
+            status: "201",
+            description: "Created",
+          },
+          name: "Created",
+          fields: [{
+            attributes: {},
+            name: "ok",
+            fieldType: {
+              type: "Plain",
+              valueTypePath: "boolean",
+            },
+            optional: false,
+          }],
+        }],
+      },
       "pkg.api.LegacyError": {
-        type: "Oneof",
+        type: "Union",
         attributes: {},
         name: "LegacyError",
         items: [{
@@ -346,10 +400,16 @@ Deno.test("generateOas keeps legacy security and status attrs for non-convention
             status: "401",
             description: "Unauthorized",
           },
-          itemType: {
-            type: "Plain",
-            valueTypePath: "pkg.api.UnauthorizedResponse",
-          },
+          name: "Unauthorized",
+          fields: [{
+            attributes: {},
+            name: "message",
+            fieldType: {
+              type: "Plain",
+              valueTypePath: "string",
+            },
+            optional: false,
+          }],
         }],
       },
       "pkg.api.LegacyProc": {
@@ -387,7 +447,7 @@ Deno.test("generateOas keeps legacy security and status attrs for non-convention
       description: "Created",
       content: {
         "application/json": {
-          schema: { $ref: "#/components/schemas/OkResponse" },
+          schema: { $ref: "#/components/schemas/LegacyOutputCreated" },
         },
       },
     },
@@ -395,7 +455,7 @@ Deno.test("generateOas keeps legacy security and status attrs for non-convention
       description: "Unauthorized",
       content: {
         "application/json": {
-          schema: { $ref: "#/components/schemas/UnauthorizedResponse" },
+          schema: { $ref: "#/components/schemas/LegacyErrorUnauthorized" },
         },
       },
     },

--- a/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
@@ -278,6 +278,130 @@ Deno.test("generateOas emits responses from oneof oas_status metadata", () => {
   });
 });
 
+Deno.test("generateOas keeps legacy security and status attrs for non-conventional schemas", () => {
+  const ir: BdlIr = {
+    modules: {
+      "pkg.api": {
+        attributes: {},
+        defPaths: [
+          "pkg.api.OkResponse",
+          "pkg.api.UnauthorizedResponse",
+          "pkg.api.LegacyOutput",
+          "pkg.api.LegacyError",
+          "pkg.api.LegacyProc",
+        ],
+        imports: [],
+      },
+    },
+    defs: {
+      "pkg.api.OkResponse": {
+        type: "Struct",
+        attributes: {},
+        name: "OkResponse",
+        fields: [{
+          attributes: {},
+          name: "ok",
+          fieldType: {
+            type: "Plain",
+            valueTypePath: "boolean",
+          },
+          optional: false,
+        }],
+      },
+      "pkg.api.UnauthorizedResponse": {
+        type: "Struct",
+        attributes: {},
+        name: "UnauthorizedResponse",
+        fields: [{
+          attributes: {},
+          name: "message",
+          fieldType: {
+            type: "Plain",
+            valueTypePath: "string",
+          },
+          optional: false,
+        }],
+      },
+      "pkg.api.LegacyOutput": {
+        type: "Oneof",
+        attributes: {},
+        name: "LegacyOutput",
+        items: [{
+          attributes: {
+            status: "201",
+            description: "Created",
+          },
+          itemType: {
+            type: "Plain",
+            valueTypePath: "pkg.api.OkResponse",
+          },
+        }],
+      },
+      "pkg.api.LegacyError": {
+        type: "Oneof",
+        attributes: {},
+        name: "LegacyError",
+        items: [{
+          attributes: {
+            status: "401",
+            description: "Unauthorized",
+          },
+          itemType: {
+            type: "Plain",
+            valueTypePath: "pkg.api.UnauthorizedResponse",
+          },
+        }],
+      },
+      "pkg.api.LegacyProc": {
+        type: "Proc",
+        attributes: {
+          http: "POST /legacy",
+          security: "legacyAuth: []",
+        },
+        name: "LegacyProc",
+        inputType: {
+          type: "Plain",
+          valueTypePath: "void",
+        },
+        outputType: {
+          type: "Plain",
+          valueTypePath: "pkg.api.LegacyOutput",
+        },
+        errorType: {
+          type: "Plain",
+          valueTypePath: "pkg.api.LegacyError",
+        },
+      },
+    },
+  };
+
+  const result = generateOas({ ir }).schema;
+  const legacyPath = result.paths?.["/legacy"];
+  if (!legacyPath || "$ref" in legacyPath) {
+    throw new Error("expected /legacy path item");
+  }
+
+  assertEquals(legacyPath.post?.security, [{ legacyAuth: [] }]);
+  assertEquals(legacyPath.post?.responses, {
+    "201": {
+      description: "Created",
+      content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/OkResponse" },
+        },
+      },
+    },
+    "401": {
+      description: "Unauthorized",
+      content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/UnauthorizedResponse" },
+        },
+      },
+    },
+  });
+});
+
 Deno.test("generateOas emits a default success response for plain outputs", () => {
   const ir: BdlIr = {
     modules: {

--- a/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
@@ -278,7 +278,7 @@ Deno.test("generateOas emits responses from oneof oas_status metadata", () => {
   });
 });
 
-Deno.test("generateOas does not synthesize descriptions for oneof responses", () => {
+Deno.test("generateOas falls back to default descriptions for oneof responses", () => {
   const ir: BdlIr = {
     modules: {
       "pkg.api": {
@@ -347,9 +347,79 @@ Deno.test("generateOas does not synthesize descriptions for oneof responses", ()
 
   assertEquals(userPath.get?.responses, {
     "200": {
+      description: "Successful response",
       content: {
         "application/json": {
           schema: { $ref: "#/components/schemas/OkResponse" },
+        },
+      },
+    },
+  });
+});
+
+Deno.test("generateOas falls back to default descriptions for union responses", () => {
+  const ir: BdlIr = {
+    modules: {
+      "pkg.api": {
+        attributes: {},
+        defPaths: [
+          "pkg.api.LegacyOutput",
+          "pkg.api.LegacyProc",
+        ],
+        imports: [],
+      },
+    },
+    defs: {
+      "pkg.api.LegacyOutput": {
+        type: "Union",
+        attributes: {},
+        name: "LegacyOutput",
+        items: [{
+          attributes: {
+            status: "201",
+          },
+          name: "Created",
+          fields: [{
+            attributes: {},
+            name: "ok",
+            fieldType: {
+              type: "Plain",
+              valueTypePath: "boolean",
+            },
+            optional: false,
+          }],
+        }],
+      },
+      "pkg.api.LegacyProc": {
+        type: "Proc",
+        attributes: {
+          http: "POST /legacy",
+        },
+        name: "LegacyProc",
+        inputType: {
+          type: "Plain",
+          valueTypePath: "void",
+        },
+        outputType: {
+          type: "Plain",
+          valueTypePath: "pkg.api.LegacyOutput",
+        },
+      },
+    },
+  };
+
+  const result = generateOas({ ir }).schema;
+  const legacyPath = result.paths?.["/legacy"];
+  if (!legacyPath || "$ref" in legacyPath) {
+    throw new Error("expected /legacy path item");
+  }
+
+  assertEquals(legacyPath.post?.responses, {
+    "201": {
+      description: "Successful response",
+      content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/LegacyOutputCreated" },
         },
       },
     },

--- a/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
@@ -189,6 +189,12 @@ Deno.test("generateOas emits responses from oneof oas_status metadata", () => {
           attributes: {
             oas_status: "200",
             description: "User loaded",
+            oas_headers: [
+              "X-Request-Id:",
+              "  description: Request trace id",
+              "  schema:",
+              "    type: string",
+            ].join("\n"),
           },
           itemType: {
             type: "Plain",
@@ -252,6 +258,12 @@ Deno.test("generateOas emits responses from oneof oas_status metadata", () => {
   assertEquals(userPath.get?.responses, {
     "200": {
       description: "User loaded",
+      headers: {
+        "X-Request-Id": {
+          description: "Request trace id",
+          schema: { type: "string" },
+        },
+      },
       content: {
         "application/json": {
           schema: { $ref: "#/components/schemas/OkResponse" },
@@ -606,4 +618,56 @@ Deno.test("generateOas ignores legacy proc summary attributes", () => {
     throw new Error("expected /legacy-summary path item");
   }
   assertEquals(legacyPath.get?.summary, undefined);
+});
+
+Deno.test("generateOas preserves void variants as null-only oneof branches", () => {
+  const ir: BdlIr = {
+    modules: {
+      "pkg.api": {
+        attributes: {},
+        defPaths: ["pkg.api.MaybeValue"],
+        imports: [],
+      },
+    },
+    defs: {
+      "pkg.api.MaybeValue": {
+        type: "Oneof",
+        attributes: {},
+        name: "MaybeValue",
+        items: [{
+          attributes: {
+            description: "Has a value",
+          },
+          itemType: {
+            type: "Plain",
+            valueTypePath: "string",
+          },
+        }, {
+          attributes: {
+            description: "No value",
+          },
+          itemType: {
+            type: "Plain",
+            valueTypePath: "void",
+          },
+        }],
+      },
+    },
+  };
+
+  const result = generateOas({ ir }).schema;
+  assertEquals(result.components?.schemas?.MaybeValue, {
+    oneOf: [
+      {
+        type: "string",
+        description: "Has a value",
+      },
+      {
+        type: "string",
+        nullable: true,
+        enum: [null],
+        description: "No value",
+      },
+    ],
+  });
 });

--- a/bdl-ts/src/generator/openapi/oas-30-generator.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.ts
@@ -171,8 +171,9 @@ function genProc(ctx: GenContext) {
     }
     const tags = parseOasTags(proc.attributes.oas_tags);
     if (tags.length) operation.tags = tags;
-    if (proc.attributes.oas_security) {
-      operation.security = parseOasSecurity(proc.attributes.oas_security);
+    const security = getAttributeFallback(proc.attributes, "oas_security", "security");
+    if (security) {
+      operation.security = parseOasSecurity(security);
     }
     operation.operationId = getOperationId(ctx, defPath);
     if (proc.inputType.valueTypePath !== "void") {
@@ -365,7 +366,11 @@ function addResponsesFromType(
     return;
   }
   for (const item of oneof.items) {
-    const status = item.attributes.oas_status || defaultStatus;
+    const status = getAttributeFallback(
+      item.attributes,
+      "oas_status",
+      "status",
+    ) || defaultStatus;
     const description = item.attributes.description || defaultDescription;
     responses[status] = buildResponse(
       ctx,
@@ -415,6 +420,14 @@ function parseOasSecurity(raw: string): oas.Oas3SecurityRequirement[] {
   const parsed = parseYaml(raw);
   if (Array.isArray(parsed)) return parsed as oas.Oas3SecurityRequirement[];
   return [parsed as oas.Oas3SecurityRequirement];
+}
+
+function getAttributeFallback(
+  attributes: Record<string, string>,
+  preferredKey: string,
+  fallbackKey: string,
+): string | undefined {
+  return attributes[preferredKey] || attributes[fallbackKey];
 }
 
 interface SchemaMetadata {

--- a/bdl-ts/src/generator/openapi/oas-30-generator.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.ts
@@ -169,7 +169,7 @@ function genProc(ctx: GenContext) {
     const tags = parseOasTags(proc.attributes.oas_tags);
     if (tags.length) operation.tags = tags;
     if (proc.attributes.oas_security) {
-      operation.security = parseYaml(proc.attributes.oas_security) as oas.Oas3SecurityRequirement[];
+      operation.security = parseOasSecurity(proc.attributes.oas_security);
     }
     operation.operationId = getOperationId(ctx, defPath);
     if (proc.inputType.valueTypePath !== "void") {
@@ -247,12 +247,11 @@ function convertFieldsToOasObject(
   if (required.length) oasSchema.required = required.map((field) => field.name);
   oasSchema.properties = {};
   for (const field of fields) {
-    const property = convertType(ctx, field.fieldType);
-    if (field.attributes.title) property.title = field.attributes.title;
-    if (field.attributes.description) {
-      property.description = field.attributes.description;
-    }
-    if (field.attributes.oas_format) property.format = field.attributes.oas_format;
+    const property = applySchemaMetadata(convertType(ctx, field.fieldType), {
+      title: field.attributes.title,
+      description: field.attributes.description,
+      format: field.attributes.oas_format,
+    });
     oasSchema.properties[field.name] = property;
   }
   return oasSchema;
@@ -336,6 +335,38 @@ function getPreferredAttribute(
 function parseOasTags(tags: string | undefined): string[] {
   if (!tags) return [];
   return tags.split(",").map((tag) => tag.trim()).filter(Boolean);
+}
+
+function parseOasSecurity(raw: string): oas.Oas3SecurityRequirement[] {
+  const parsed = parseYaml(raw);
+  if (Array.isArray(parsed)) return parsed as oas.Oas3SecurityRequirement[];
+  return [parsed as oas.Oas3SecurityRequirement];
+}
+
+interface SchemaMetadata {
+  title?: string;
+  description?: string;
+  format?: string;
+}
+
+function applySchemaMetadata(
+  schema: oas.Oas3Schema,
+  metadata: SchemaMetadata,
+): oas.Oas3Schema {
+  const { title, description, format } = metadata;
+  if (!title && !description && !format) return schema;
+  if ("$ref" in schema) {
+    return {
+      allOf: [schema],
+      ...(title ? { title } : {}),
+      ...(description ? { description } : {}),
+      ...(format ? { format } : {}),
+    };
+  }
+  if (title) schema.title = title;
+  if (description) schema.description = description;
+  if (format) schema.format = format;
+  return schema;
 }
 
 function getOperationId(ctx: GenContext, typePath: string) {

--- a/bdl-ts/src/generator/openapi/oas-30-generator.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.ts
@@ -161,9 +161,15 @@ function genProc(ctx: GenContext) {
     )!;
     const path = (paths[httpPath] ||= {}) as OasPathItem;
     const operation = {} as OasOperation;
-    if (proc.attributes.summary) operation.summary = proc.attributes.summary;
+    const summary = getPreferredAttribute(proc.attributes, "oas_summary", "summary");
+    if (summary) operation.summary = summary;
     if (proc.attributes.description) {
       operation.description = proc.attributes.description;
+    }
+    const tags = parseOasTags(proc.attributes.oas_tags);
+    if (tags.length) operation.tags = tags;
+    if (proc.attributes.oas_security) {
+      operation.security = parseYaml(proc.attributes.oas_security) as oas.Oas3SecurityRequirement[];
     }
     operation.operationId = getOperationId(ctx, defPath);
     if (proc.inputType.valueTypePath !== "void") {
@@ -246,6 +252,7 @@ function convertFieldsToOasObject(
     if (field.attributes.description) {
       property.description = field.attributes.description;
     }
+    if (field.attributes.oas_format) property.format = field.attributes.oas_format;
     oasSchema.properties[field.name] = property;
   }
   return oasSchema;
@@ -316,6 +323,19 @@ function convertPrimitive(typePath: string): oas.Oas3Schema {
 
 function pascalToCamelCase(str: string): string {
   return str[0].toLowerCase() + str.slice(1);
+}
+
+function getPreferredAttribute(
+  attributes: Record<string, string>,
+  preferredKey: string,
+  legacyKey?: string,
+): string | undefined {
+  return attributes[preferredKey] || (legacyKey ? attributes[legacyKey] : undefined);
+}
+
+function parseOasTags(tags: string | undefined): string[] {
+  if (!tags) return [];
+  return tags.split(",").map((tag) => tag.trim()).filter(Boolean);
 }
 
 function getOperationId(ctx: GenContext, typePath: string) {

--- a/bdl-ts/src/generator/openapi/oas-30-generator.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.ts
@@ -171,7 +171,11 @@ function genProc(ctx: GenContext) {
     }
     const tags = parseOasTags(proc.attributes.oas_tags);
     if (tags.length) operation.tags = tags;
-    const security = getAttributeFallback(proc.attributes, "oas_security", "security");
+    const security = getAttributeFallback(
+      proc.attributes,
+      "oas_security",
+      "security",
+    );
     if (security) {
       operation.security = parseOasSecurity(security);
     }
@@ -363,7 +367,7 @@ function addResponsesFromType(
       responses[status] = buildResponse(
         ctx,
         item.itemType,
-        item.attributes.description,
+        item.attributes.description || defaultDescription,
         item.attributes.example,
       );
     }
@@ -376,7 +380,7 @@ function addResponsesFromType(
       responses[status] = buildResponse(
         ctx,
         { type: "Plain", valueTypePath: `${unionInfo.defPath}::${item.name}` },
-        item.attributes.description,
+        item.attributes.description || defaultDescription,
       );
     }
     return;

--- a/bdl-ts/src/generator/openapi/oas-30-generator.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.ts
@@ -7,6 +7,8 @@ type OasPaths = oas.Oas3Paths<oas.Oas3Schema>;
 type OasPathItem = oas.Oas3PathItem<oas.Oas3Schema>;
 type OasOperation = oas.Oas3Operation<oas.Oas3Schema>;
 type OasMediaType = oas.Oas3MediaType<oas.Oas3Schema>;
+type OasResponse = oas.Oas3Response<oas.Oas3Schema>;
+type OasResponses = oas.Oas3Responses<oas.Oas3Schema>;
 interface OasComponentSchemas {
   [name: string]: oas.Referenced<oas.Oas3Schema>;
 }
@@ -161,8 +163,9 @@ function genProc(ctx: GenContext) {
     )!;
     const path = (paths[httpPath] ||= {}) as OasPathItem;
     const operation = {} as OasOperation;
-    const summary = getPreferredAttribute(proc.attributes, "oas_summary", "summary");
-    if (summary) operation.summary = summary;
+    if (proc.attributes.oas_summary) {
+      operation.summary = proc.attributes.oas_summary;
+    }
     if (proc.attributes.description) {
       operation.description = proc.attributes.description;
     }
@@ -183,7 +186,7 @@ function genProc(ctx: GenContext) {
         content: { "application/json": mediaType },
       };
     }
-    operation.responses = {};
+    operation.responses = buildResponses(ctx, proc);
     path[httpMethod.toLowerCase() as "get"] = operation;
   } catch {
     throw new GenerateOasError(`Invalid Proc: ${defPath}`);
@@ -324,12 +327,83 @@ function pascalToCamelCase(str: string): string {
   return str[0].toLowerCase() + str.slice(1);
 }
 
-function getPreferredAttribute(
-  attributes: Record<string, string>,
-  preferredKey: string,
-  legacyKey?: string,
-): string | undefined {
-  return attributes[preferredKey] || (legacyKey ? attributes[legacyKey] : undefined);
+function buildResponses(ctx: GenContext, proc: ir.Proc): OasResponses {
+  const responses: OasResponses = {};
+  addResponsesFromType(
+    ctx,
+    responses,
+    proc.outputType,
+    "200",
+    "Successful response",
+  );
+  if (proc.errorType) {
+    addResponsesFromType(
+      ctx,
+      responses,
+      proc.errorType,
+      "default",
+      "Error response",
+    );
+  }
+  return responses;
+}
+
+function addResponsesFromType(
+  ctx: GenContext,
+  responses: OasResponses,
+  type: ir.Type,
+  defaultStatus: string,
+  defaultDescription: string,
+) {
+  const oneof = getReferencedOneof(ctx, type);
+  if (!oneof) {
+    responses[defaultStatus] = buildResponse(
+      ctx,
+      type,
+      defaultDescription,
+    );
+    return;
+  }
+  for (const item of oneof.items) {
+    const status = item.attributes.oas_status || defaultStatus;
+    const description = item.attributes.description || defaultDescription;
+    responses[status] = buildResponse(
+      ctx,
+      item.itemType,
+      description,
+      item.attributes.example,
+    );
+  }
+}
+
+function buildResponse(
+  ctx: GenContext,
+  type: ir.Type,
+  description: string,
+  example?: string,
+): OasResponse {
+  const response: OasResponse = { description };
+  if (isVoidType(type)) return response;
+  const mediaType: OasMediaType = {
+    schema: convertType(ctx, type),
+  };
+  if (example) mediaType.example = parseYaml(example);
+  response.content = { "application/json": mediaType };
+  return response;
+}
+
+function getReferencedOneof(
+  ctx: GenContext,
+  type: ir.Type,
+): ir.Oneof | undefined {
+  if (type.type !== "Plain") return undefined;
+  const def = ctx.input.config.ir.defs[type.valueTypePath];
+  if (def?.type !== "Oneof") return undefined;
+  return def;
+}
+
+function isVoidType(type: ir.Type): boolean {
+  return type.type === "Plain" && type.valueTypePath === "void";
 }
 
 function parseOasTags(tags: string | undefined): string[] {

--- a/bdl-ts/src/generator/openapi/oas-30-generator.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.ts
@@ -357,37 +357,45 @@ function addResponsesFromType(
   defaultDescription: string,
 ) {
   const oneof = getReferencedOneof(ctx, type);
-  if (!oneof) {
-    responses[defaultStatus] = buildResponse(
-      ctx,
-      type,
-      defaultDescription,
-    );
+  if (oneof) {
+    for (const item of oneof.items) {
+      const status = item.attributes.oas_status || defaultStatus;
+      responses[status] = buildResponse(
+        ctx,
+        item.itemType,
+        item.attributes.description,
+        item.attributes.example,
+      );
+    }
     return;
   }
-  for (const item of oneof.items) {
-    const status = getAttributeFallback(
-      item.attributes,
-      "oas_status",
-      "status",
-    ) || defaultStatus;
-    const description = item.attributes.description || defaultDescription;
-    responses[status] = buildResponse(
-      ctx,
-      item.itemType,
-      description,
-      item.attributes.example,
-    );
+  const unionInfo = getReferencedUnionInfo(ctx, type);
+  if (unionInfo) {
+    for (const item of unionInfo.def.items) {
+      const status = item.attributes.status || defaultStatus;
+      responses[status] = buildResponse(
+        ctx,
+        { type: "Plain", valueTypePath: `${unionInfo.defPath}::${item.name}` },
+        item.attributes.description,
+      );
+    }
+    return;
   }
+  responses[defaultStatus] = buildResponse(
+    ctx,
+    type,
+    defaultDescription,
+  );
 }
 
 function buildResponse(
   ctx: GenContext,
   type: ir.Type,
-  description: string,
+  description?: string,
   example?: string,
 ): OasResponse {
-  const response: OasResponse = { description };
+  const response = {} as OasResponse;
+  if (description) response.description = description;
   if (isVoidType(type)) return response;
   const mediaType: OasMediaType = {
     schema: convertType(ctx, type),
@@ -405,6 +413,16 @@ function getReferencedOneof(
   const def = ctx.input.config.ir.defs[type.valueTypePath];
   if (def?.type !== "Oneof") return undefined;
   return def;
+}
+
+function getReferencedUnionInfo(
+  ctx: GenContext,
+  type: ir.Type,
+): { defPath: string; def: ir.Union } | undefined {
+  if (type.type !== "Plain") return undefined;
+  const def = ctx.input.config.ir.defs[type.valueTypePath];
+  if (def?.type !== "Union") return undefined;
+  return { defPath: type.valueTypePath, def };
 }
 
 function isVoidType(type: ir.Type): boolean {

--- a/bdl-ts/src/generator/openapi/oas-30-generator.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.ts
@@ -8,6 +8,10 @@ type OasPathItem = oas.Oas3PathItem<oas.Oas3Schema>;
 type OasOperation = oas.Oas3Operation<oas.Oas3Schema>;
 type OasMediaType = oas.Oas3MediaType<oas.Oas3Schema>;
 type OasResponse = oas.Oas3Response<oas.Oas3Schema>;
+type OasHeaders = Record<
+  string,
+  oas.Referenced<oas.Oas3Header<oas.Oas3Schema>>
+>;
 type OasResponses = oas.Oas3Responses<oas.Oas3Schema>;
 interface OasComponentSchemas {
   [name: string]: oas.Referenced<oas.Oas3Schema>;
@@ -143,13 +147,19 @@ function genOneof(ctx: GenContext) {
   if (oneof.attributes.description) {
     oasSchema.description = oneof.attributes.description;
   }
-  oasSchema.oneOf = oneof.items.map((item) => {
-    const itemSchema = convertType(ctx, item.itemType);
-    if (item.attributes.title) itemSchema.title = item.attributes.title;
-    if (item.attributes.description) {
-      itemSchema.description = item.attributes.description;
-    }
-    return itemSchema;
+  oasSchema.oneOf = oneof.items.map((item) => convertOneofItem(ctx, item));
+}
+
+function convertOneofItem(
+  ctx: GenContext,
+  item: ir.OneofItem,
+): oas.Oas3Schema {
+  const itemSchema: oas.Oas3Schema = isVoidType(item.itemType)
+    ? { type: "string", nullable: true, enum: [null] }
+    : convertType(ctx, item.itemType);
+  return applySchemaMetadata(itemSchema, {
+    title: item.attributes.title,
+    description: item.attributes.description,
   });
 }
 
@@ -369,6 +379,7 @@ function addResponsesFromType(
         item.itemType,
         item.attributes.description || defaultDescription,
         item.attributes.example,
+        item.attributes.oas_headers,
       );
     }
     return;
@@ -381,6 +392,8 @@ function addResponsesFromType(
         ctx,
         { type: "Plain", valueTypePath: `${unionInfo.defPath}::${item.name}` },
         item.attributes.description || defaultDescription,
+        undefined,
+        item.attributes.oas_headers,
       );
     }
     return;
@@ -397,9 +410,11 @@ function buildResponse(
   type: ir.Type,
   description?: string,
   example?: string,
+  headers?: string,
 ): OasResponse {
   const response = {} as OasResponse;
   if (description) response.description = description;
+  if (headers) response.headers = parseYaml(headers) as OasHeaders;
   if (isVoidType(type)) return response;
   const mediaType: OasMediaType = {
     schema: convertType(ctx, type),

--- a/bdl-ts/src/linter/bdl.test.ts
+++ b/bdl-ts/src/linter/bdl.test.ts
@@ -33,6 +33,26 @@ Deno.test("lintBdl reports unknown attributes", async () => {
   assert(messages.includes("Unknown attribute 'nope'."));
 });
 
+Deno.test("lintBdl accepts example on conventional oneof items", async () => {
+  const result = await lintBdlFinal({
+    text: [
+      "# standard - conventional",
+      "oneof ApiError =",
+      "  @ oas_status - 400",
+      '  @ example - {"message":"boom"}',
+      "  ErrorResponse",
+      "",
+      "struct ErrorResponse {",
+      "  message: string,",
+      "}",
+      "",
+    ].join("\n"),
+    standard: conventionalStandard,
+  });
+  const messages = result.diagnostics.map((diag) => diag.message);
+  assert(!messages.includes("Unknown attribute 'example'."));
+});
+
 Deno.test("lintBdl requires standard by default", async () => {
   const result = await lintBdlFinal({ text: "struct User { id: string }\n" });
   const messages = result.diagnostics.map((diag) => diag.message);

--- a/deno.lock
+++ b/deno.lock
@@ -43,7 +43,7 @@
     "jsr:@ts-morph/common@0.27": "0.27.0",
     "npm:@redocly/openapi-core@1.34.1": "1.34.1",
     "npm:@rspack/core@1": "1.3.5",
-    "npm:@types/node@*": "22.5.4",
+    "npm:@types/node@*": "22.7.5",
     "npm:@types/node@^22.7.5": "22.7.5",
     "npm:@types/vscode@*": "1.94.0",
     "npm:@types/vscode@^1.92.0": "1.94.0",
@@ -54,6 +54,7 @@
     "npm:chokidar-cli@3.0.0": "3.0.0",
     "npm:js-yaml@4.1.0": "4.1.0",
     "npm:js-yaml@^4.1.0": "4.1.0",
+    "npm:jsonc-parser@3": "3.3.1",
     "npm:tsup@8.4.0": "8.4.0_typescript@5.8.2_esbuild@0.25.0_yaml@2.8.2",
     "npm:tsup@^8.4.0": "8.4.0_typescript@5.8.2_esbuild@0.25.0_yaml@2.8.2",
     "npm:typescript@^5.8.2": "5.8.2",
@@ -726,12 +727,6 @@
     },
     "@types/estree@1.0.6": {
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
-    },
-    "@types/node@22.5.4": {
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
-      "dependencies": [
-        "undici-types"
-      ]
     },
     "@types/node@22.7.5": {
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
@@ -2531,6 +2526,7 @@
           "jsr:@std/path@1",
           "jsr:@std/yaml@1",
           "npm:@redocly/openapi-core@1.34.1",
+          "npm:jsonc-parser@3",
           "npm:yaml@2"
         ]
       },

--- a/docs/standard.md
+++ b/docs/standard.md
@@ -67,9 +67,10 @@ use the explicit `oas_*` keys rather than generic names.
 
 - On `proc`, use `oas_summary`, `oas_tags`, and `oas_security`.
 - On `struct` fields, use `oas_format` for OpenAPI string formats such as `email` or `date-time`.
-- On `oneof` items, use `oas_status` for response status mapping.
+- On `oneof` items used in `proc` output or error types, use `oas_status` for OpenAPI response status mapping.
 
-The official OpenAPI generator accepts these `oas_*` keys directly.
+The official OpenAPI generator accepts these `oas_*` keys directly
+and maps `oas_status` entries to `responses` in the generated operation schema.
 
 ## Primitive Types
 

--- a/docs/standard.md
+++ b/docs/standard.md
@@ -76,10 +76,13 @@ explicit `oas_*` keys rather than generic names.
 - On `struct` fields, use `oas_format` for OpenAPI string formats such as
   `email` or `date-time`.
 - On `oneof` items used in `proc` output or error types, use `oas_status` for
-  OpenAPI response status mapping and `example` for response examples.
+  OpenAPI response status mapping.
+- On response variants, use `example` for response examples and `oas_headers`
+  when you need to preserve raw OpenAPI response header definitions.
 
 The official OpenAPI generator accepts these `oas_*` keys directly and maps
 `oas_status` entries to `responses` in the generated operation schema.
+`oas_headers` should contain the OpenAPI `headers` object serialized as YAML.
 
 ## Primitive Types
 

--- a/docs/standard.md
+++ b/docs/standard.md
@@ -1,26 +1,31 @@
 # Standard
 
-BDL aims to support various serialization formats and RPC protocols based on a common grammar.
-However, in reality, there are too many formats and protocols with differing supported features
-and design philosophies, making it difficult to cover all of them perfectly with a single standard.
+BDL aims to support various serialization formats and RPC protocols based on a
+common grammar. However, in reality, there are too many formats and protocols
+with differing supported features and design philosophies, making it difficult
+to cover all of them perfectly with a single standard.
 
-Therefore, BDL introduces the `standard` attribute,
-which specifies the conventions to be applied on a per-file basis.
-This allows each file to clearly define
-"which primitive types are provided, and which serialization formats and RPC protocols are to be used."
+Therefore, BDL introduces the `standard` attribute, which specifies the
+conventions to be applied on a per-file basis. This allows each file to clearly
+define "which primitive types are provided, and which serialization formats and
+RPC protocols are to be used."
 
-Details on the syntax of BDL files are covered in the [BDL Syntax](./syntax.md) document.\
-The actual contents of BDL files are covered in the [Intermediate Representation (IR)](./ir.md) document.
+Details on the syntax of BDL files are covered in the [BDL Syntax](./syntax.md)
+document.\
+The actual contents of BDL files are covered in the
+[Intermediate Representation (IR)](./ir.md) document.
 
 # The `conventional` standard
 
-This document aims to explain the BDL standard called `conventional`.
-The official tooling provided by BDL will understand and support the conventional standard well.
-While BDL generally encourages defining and using your own standard tailored to your specific situation,
-for those who are unsure about what to define and how to use it,
-the `conventional` standard will serve as a good starting point.
+This document aims to explain the BDL standard called `conventional`. The
+official tooling provided by BDL will understand and support the conventional
+standard well. While BDL generally encourages defining and using your own
+standard tailored to your specific situation, for those who are unsure about
+what to define and how to use it, the `conventional` standard will serve as a
+good starting point.
 
-First, all BDL files begin by specifying which standard is designated for that file.
+First, all BDL files begin by specifying which standard is designated for that
+file.
 
 ```bdl
 # standard - conventional
@@ -28,12 +33,13 @@ First, all BDL files begin by specifying which standard is designated for that f
 
 ## Naming convention
 
-Each type definition within a module,
-regardless of its form (`custom`, `enum`, `oneof`, `proc`, `struct`, or `union`),
-must have a unique name within that module.
+Each type definition within a module, regardless of its form (`custom`, `enum`,
+`oneof`, `proc`, `struct`, or `union`), must have a unique name within that
+module.
 
-And because there are environments like Swift or OpenAPI where namespaces are not properly supported,
-type definitions should also have unique names within the global module tree whenever possible.
+And because there are environments like Swift or OpenAPI where namespaces are
+not properly supported, type definitions should also have unique names within
+the global module tree whenever possible.
 
 Package names and each segment of a module path should follow _snake_case_.\
 Attribute names should follow _snake_case_.\
@@ -53,7 +59,8 @@ struct MyStruct {
 ```
 
 Since code generation may adapt naming to conventions of each target language,
-acronyms in _camelCase_ or _PascalCase_ should be treated as if they were regular words.
+acronyms in _camelCase_ or _PascalCase_ should be treated as if they were
+regular words.
 
 e.g.
 
@@ -62,15 +69,17 @@ e.g.
 
 ## OpenAPI Metadata Attributes
 
-When attaching OpenAPI-specific metadata in the `conventional` standard,
-use the explicit `oas_*` keys rather than generic names.
+When attaching OpenAPI-specific metadata in the `conventional` standard, use the
+explicit `oas_*` keys rather than generic names.
 
 - On `proc`, use `oas_summary`, `oas_tags`, and `oas_security`.
-- On `struct` fields, use `oas_format` for OpenAPI string formats such as `email` or `date-time`.
-- On `oneof` items used in `proc` output or error types, use `oas_status` for OpenAPI response status mapping.
+- On `struct` fields, use `oas_format` for OpenAPI string formats such as
+  `email` or `date-time`.
+- On `oneof` items used in `proc` output or error types, use `oas_status` for
+  OpenAPI response status mapping and `example` for response examples.
 
-The official OpenAPI generator accepts these `oas_*` keys directly
-and maps `oas_status` entries to `responses` in the generated operation schema.
+The official OpenAPI generator accepts these `oas_*` keys directly and maps
+`oas_status` entries to `responses` in the generated operation schema.
 
 ## Primitive Types
 
@@ -79,41 +88,57 @@ and maps `oas_status` entries to `responses` in the generated operation schema.
 >
 > In some environments where 64-bit integers are not fully supported,
 > [only up to 53 bits may be safely represented](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER).\
-> For example, JavaScript’s `JSON.parse` function interprets all numeric input as 64-bit floating-point numbers,
-> which can lead to precision loss for 64-bit integers.
+> For example, JavaScript’s `JSON.parse` function interprets all numeric input
+> as 64-bit floating-point numbers, which can lead to precision loss for 64-bit
+> integers.
 >
-> Although the official implementation of BDL handles JSON parsing directly to preserve data as much as possible,
-> if the JSON is already parsed by the framework before BDL processes it, the information may already be lost.
+> Although the official implementation of BDL handles JSON parsing directly to
+> preserve data as much as possible, if the JSON is already parsed by the
+> framework before BDL processes it, the information may already be lost.
 >
-> In Swift as well, integers that exceed the 64-bit range may be interpreted as 64-bit floating-point numbers, leading to similar issues.
+> In Swift as well, integers that exceed the 64-bit range may be interpreted as
+> 64-bit floating-point numbers, leading to similar issues.
 
 - `boolean`: Represents `true` or `false`
 - `int32`: A 32-bit integer ranging from `-2147483648` to `2147483647`
-- `int64`: A 64-bit integer ranging from `-9223372036854775808` to `9223372036854775807`
+- `int64`: A 64-bit integer ranging from `-9223372036854775808` to
+  `9223372036854775807`
 - `integer`: An arbitrary integer including negative numbers
-- `float64`: [A 64-bit IEEE 754 floating-point number](https://en.wikipedia.org/wiki/Double-precision_floating-point_format)
+- `float64`:
+  [A 64-bit IEEE 754 floating-point number](https://en.wikipedia.org/wiki/Double-precision_floating-point_format)
 - `string`: A unicode string
 - `bytes`: A byte array
 - `object`: A dictionary with string keys and values of any type
 - `void`: Represents the absence of a value
-  - It can only be specified as the input or output type in a [Proc declaration](./syntax.md#Proc)
+  - It can only be specified as the input or output type in a
+    [Proc declaration](./syntax.md#Proc)
 
 ## JSON Ser/Des
 
 The JSON serialization format is useful in a variety of situations.
 
-It is commonly used when writing runtime objects to files and is also a supported type in major relational databases.\
-In particular, it is used as the data format exchanged between server and client in OpenAPI and JSON RPC.
+It is commonly used when writing runtime objects to files and is also a
+supported type in major relational databases.\
+In particular, it is used as the data format exchanged between server and client
+in OpenAPI and JSON RPC.
 
-Therefore, the BDL conventional standard places a strong emphasis on JSON serialization and deserialization.
+Therefore, the BDL conventional standard places a strong emphasis on JSON
+serialization and deserialization.
 
 ### JSON Ser/Des - Primitive types
 
-- The `boolean`, numeric (`int32`, `int64`, `integer`, `float64`), and `string` types are serialized to JSON in an obvious manner.
-  - For the `float64` type, when attempting to serialize values like `NaN`, `Infinity`, or `-Infinity`, the behavior is implementation defined.\
-    The implementation must choose whether to serialize them as `null`, as the strings `"NaN"`, `"Infinity"`, or `"-Infinity"`, or to raise an error, and document this choice in its specification.
-  - When deserializing `null` into a `float64`, the behavior is implementation defined.\
-    The implementation must choose whether to deserialize it as `0` or as `NaN`, and document this choice in its specification.
+- The `boolean`, numeric (`int32`, `int64`, `integer`, `float64`), and `string`
+  types are serialized to JSON in an obvious manner.
+  - For the `float64` type, when attempting to serialize values like `NaN`,
+    `Infinity`, or `-Infinity`, the behavior is implementation defined.\
+    The implementation must choose whether to serialize them as `null`, as the
+    strings `"NaN"`, `"Infinity"`, or `"-Infinity"`, or to raise an error, and
+    document this choice in its specification.
+  - When deserializing `null` into a `float64`, the behavior is implementation
+    defined.\
+    The implementation must choose whether to deserialize it as `0` or as `NaN`,
+    and document this choice in its specification.
 - The `bytes` type is serialized as a base64-encoded string.
-- The `object` type is serialized as a JSON object.
-  The keys are straightforward, but the serialization behavior for the values is unspecified and depends on the implementation.
+- The `object` type is serialized as a JSON object. The keys are
+  straightforward, but the serialization behavior for the values is unspecified
+  and depends on the implementation.

--- a/docs/standard.md
+++ b/docs/standard.md
@@ -60,6 +60,17 @@ e.g.
 - Use `HttpRequest` instead of `HTTPRequest`
 - Use `userId` instead of `userID`
 
+## OpenAPI Metadata Attributes
+
+When attaching OpenAPI-specific metadata in the `conventional` standard,
+use the explicit `oas_*` keys rather than generic names.
+
+- On `proc`, use `oas_summary`, `oas_tags`, and `oas_security`.
+- On `struct` fields, use `oas_format` for OpenAPI string formats such as `email` or `date-time`.
+- On `oneof` items, use `oas_status` for response status mapping.
+
+The official OpenAPI generator accepts these `oas_*` keys directly.
+
 ## Primitive Types
 
 > [!WARNING]

--- a/example-schemas/swagger-petstore/generated/petstore/user.bdl
+++ b/example-schemas/swagger-petstore/generated/petstore/user.bdl
@@ -59,6 +59,17 @@ struct LoginUserInput {
 oneof LoginUserOutput {
   @ oas_status - 200
   @ description - successful operation
+  @ oas_headers
+  | X-Rate-Limit:
+  |   description: calls per hour allowed by the user
+  |   schema:
+  |     type: integer
+  |     format: int32
+  | X-Expires-After:
+  |   description: date in UTC when token expires
+  |   schema:
+  |     type: string
+  |     format: date-time
   string,
 }
 

--- a/example-schemas/swagger-petstore/scripts/convert-petstore.ts
+++ b/example-schemas/swagger-petstore/scripts/convert-petstore.ts
@@ -391,7 +391,7 @@ function buildOperationOutput(
       item.attributes.description = response.description;
     }
     if (response.headers) {
-      console.log("headers in responses are not implemented yet");
+      item.attributes.oas_headers = stringifyYaml(response.headers).trim();
     }
     const example = pickExample(response);
     if (example) item.attributes.example = JSON.stringify(example);
@@ -422,6 +422,9 @@ function buildOperationError(
     const item: ir.OneofItem = { attributes: { oas_status: status }, itemType };
     if (response.description) {
       item.attributes.description = response.description;
+    }
+    if (response.headers) {
+      item.attributes.oas_headers = stringifyYaml(response.headers).trim();
     }
     const example = pickExample(response);
     if (example) item.attributes.example = JSON.stringify(example);

--- a/standards/conventional.yaml
+++ b/standards/conventional.yaml
@@ -67,11 +67,19 @@ attributes:
       description: |-
         Provides an example value for this response variant.
         Used for generated OpenAPI response examples.
+    - key: oas_headers
+      description: |-
+        OpenAPI response header map serialized as YAML.
+        Preserves response-specific header definitions for OpenAPI round-tripping.
   bdl.union.item:
     - key: status
       description: |-
         HTTP status code for this response variant.
         Example: "200", "400", "404", "500", "default"
+    - key: oas_headers
+      description: |-
+        OpenAPI response header map serialized as YAML.
+        Preserves response-specific header definitions for OpenAPI round-tripping.
   bdl.proc:
     - key: http
       description: |-

--- a/standards/conventional.yaml
+++ b/standards/conventional.yaml
@@ -63,6 +63,10 @@ attributes:
       description: |-
         HTTP status code string as provided by the OpenAPI response map.
         Example: "200", "400", "404", "500", "default"
+    - key: example
+      description: |-
+        Provides an example value for this response variant.
+        Used for generated OpenAPI response examples.
   bdl.union.item:
     - key: status
       description: |-


### PR DESCRIPTION
## Summary
- align the OpenAPI generator with the conventional `oas_*` attribute contract
- add unit coverage for `oas_summary`, `oas_tags`, `oas_security`, and `oas_format`
- generate OpenAPI `responses` from proc output and error `oneof` variants via `oas_status`
- document the conventional OpenAPI metadata keys and record response-header follow-up work (#61)

## Testing
- `deno test bdl-ts/src/generator/openapi/oas-30-generator.test.ts`

Fixes #54
Fixes #58
Refs #61