### PR TITLE
Fix JSON union discriminator serialization

### DIFF
--- a/bdl-ts/runtime/src/json-ser-des.test.ts
+++ b/bdl-ts/runtime/src/json-ser-des.test.ts
@@ -1,0 +1,21 @@
+import { assertEquals } from "@std/assert";
+import { createPrimitiveDefs, defineUnion, f, p } from "./data-schema.ts";
+import { ser } from "./json-ser-des.ts";
+
+Deno.test("ser serializes union discriminator values as JSON strings", () => {
+  const defs = createPrimitiveDefs();
+  defineUnion(
+    "Result",
+    "kind",
+    {
+      ok: [f("value", p("string"))],
+      err: [f("message", p("string"))],
+    },
+    defs,
+  );
+
+  assertEquals(
+    ser(defs.Result, { kind: "ok", value: "done" }, defs),
+    '{"kind":"ok","value":"done"}',
+  );
+});

--- a/bdl-ts/runtime/src/json-ser-des.ts
+++ b/bdl-ts/runtime/src/json-ser-des.ts
@@ -48,7 +48,7 @@ export function ser<T>(schema: Schema<T>, data: T, defs = globalDefs): string {
       return `{${serFields(schema.fields, data, defs)}}`;
     case "Union": {
       const type = (data as Record<string, string>)[schema.discriminator];
-      return `{${JSON.stringify(schema.discriminator)}:${type},${
+      return `{${JSON.stringify(schema.discriminator)}:${JSON.stringify(type)},${
         serFields(schema.items[type], data, defs)
       }}`;
     }

--- a/docs/standard.md
+++ b/docs/standard.md
@@ -105,3 +105,9 @@ Therefore, the BDL conventional standard places a strong emphasis on JSON serial
 - The `bytes` type is serialized as a base64-encoded string.
 - The `object` type is serialized as a JSON object.
   The keys are straightforward, but the serialization behavior for the values is unspecified and depends on the implementation.
+
+### JSON Ser/Des - Union types
+
+- A `union` value is serialized as a JSON object.
+- The discriminator field must be emitted as a normal JSON string field, using the union's discriminator key.
+- The remaining fields are serialized according to the selected union item.


### PR DESCRIPTION
## Summary
- serialize union discriminator values as JSON strings in the runtime serializer
- add a regression test for union JSON output
- document the expected JSON union encoding in the conventional standard docs

Fixes #50