### PR TITLE
Preserve OpenAPI response headers

### DIFF
--- a/bdl-ts/src/generated/json/conventional.json
+++ b/bdl-ts/src/generated/json/conventional.json
@@ -78,12 +78,20 @@
       {
         "key": "example",
         "description": "Provides an example value for this response variant.\nUsed for generated OpenAPI response examples."
+      },
+      {
+        "key": "oas_headers",
+        "description": "OpenAPI response header map serialized as YAML.\nPreserves response-specific header definitions for OpenAPI round-tripping."
       }
     ],
     "bdl.union.item": [
       {
         "key": "status",
         "description": "HTTP status code for this response variant.\nExample: \"200\", \"400\", \"404\", \"500\", \"default\""
+      },
+      {
+        "key": "oas_headers",
+        "description": "OpenAPI response header map serialized as YAML.\nPreserves response-specific header definitions for OpenAPI round-tripping."
       }
     ],
     "bdl.proc": [

--- a/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
@@ -189,6 +189,12 @@ Deno.test("generateOas emits responses from oneof oas_status metadata", () => {
           attributes: {
             oas_status: "200",
             description: "User loaded",
+            oas_headers: [
+              "X-Request-Id:",
+              "  description: Request trace id",
+              "  schema:",
+              "    type: string",
+            ].join("\n"),
           },
           itemType: {
             type: "Plain",
@@ -252,6 +258,12 @@ Deno.test("generateOas emits responses from oneof oas_status metadata", () => {
   assertEquals(userPath.get?.responses, {
     "200": {
       description: "User loaded",
+      headers: {
+        "X-Request-Id": {
+          description: "Request trace id",
+          schema: { type: "string" },
+        },
+      },
       content: {
         "application/json": {
           schema: { $ref: "#/components/schemas/OkResponse" },
@@ -606,4 +618,51 @@ Deno.test("generateOas ignores legacy proc summary attributes", () => {
     throw new Error("expected /legacy-summary path item");
   }
   assertEquals(legacyPath.get?.summary, undefined);
+});
+
+Deno.test("generateOas collapses void variants to nullable oneof schemas", () => {
+  const ir: BdlIr = {
+    modules: {
+      "pkg.api": {
+        attributes: {},
+        defPaths: ["pkg.api.MaybeValue"],
+        imports: [],
+      },
+    },
+    defs: {
+      "pkg.api.MaybeValue": {
+        type: "Oneof",
+        attributes: {},
+        name: "MaybeValue",
+        items: [{
+          attributes: {
+            description: "Has a value",
+          },
+          itemType: {
+            type: "Plain",
+            valueTypePath: "string",
+          },
+        }, {
+          attributes: {
+            description: "No value",
+          },
+          itemType: {
+            type: "Plain",
+            valueTypePath: "void",
+          },
+        }],
+      },
+    },
+  };
+
+  const result = generateOas({ ir }).schema;
+  assertEquals(result.components?.schemas?.MaybeValue, {
+    nullable: true,
+    oneOf: [
+      {
+        type: "string",
+        description: "Has a value",
+      },
+    ],
+  });
 });

--- a/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.test.ts
@@ -620,7 +620,7 @@ Deno.test("generateOas ignores legacy proc summary attributes", () => {
   assertEquals(legacyPath.get?.summary, undefined);
 });
 
-Deno.test("generateOas collapses void variants to nullable oneof schemas", () => {
+Deno.test("generateOas preserves void variants as null-only oneof branches", () => {
   const ir: BdlIr = {
     modules: {
       "pkg.api": {
@@ -657,11 +657,16 @@ Deno.test("generateOas collapses void variants to nullable oneof schemas", () =>
 
   const result = generateOas({ ir }).schema;
   assertEquals(result.components?.schemas?.MaybeValue, {
-    nullable: true,
     oneOf: [
       {
         type: "string",
         description: "Has a value",
+      },
+      {
+        type: "string",
+        nullable: true,
+        enum: [null],
+        description: "No value",
       },
     ],
   });

--- a/bdl-ts/src/generator/openapi/oas-30-generator.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.ts
@@ -8,6 +8,10 @@ type OasPathItem = oas.Oas3PathItem<oas.Oas3Schema>;
 type OasOperation = oas.Oas3Operation<oas.Oas3Schema>;
 type OasMediaType = oas.Oas3MediaType<oas.Oas3Schema>;
 type OasResponse = oas.Oas3Response<oas.Oas3Schema>;
+type OasHeaders = Record<
+  string,
+  oas.Referenced<oas.Oas3Header<oas.Oas3Schema>>
+>;
 type OasResponses = oas.Oas3Responses<oas.Oas3Schema>;
 interface OasComponentSchemas {
   [name: string]: oas.Referenced<oas.Oas3Schema>;
@@ -143,14 +147,22 @@ function genOneof(ctx: GenContext) {
   if (oneof.attributes.description) {
     oasSchema.description = oneof.attributes.description;
   }
-  oasSchema.oneOf = oneof.items.map((item) => {
-    const itemSchema = convertType(ctx, item.itemType);
-    if (item.attributes.title) itemSchema.title = item.attributes.title;
-    if (item.attributes.description) {
-      itemSchema.description = item.attributes.description;
-    }
-    return itemSchema;
-  });
+  const concreteItems = oneof.items.filter((item) =>
+    !isVoidType(item.itemType)
+  );
+  if (concreteItems.length) {
+    oasSchema.oneOf = concreteItems.map((item) => {
+      const itemSchema = convertType(ctx, item.itemType);
+      if (item.attributes.title) itemSchema.title = item.attributes.title;
+      if (item.attributes.description) {
+        itemSchema.description = item.attributes.description;
+      }
+      return itemSchema;
+    });
+  }
+  if (concreteItems.length !== oneof.items.length) {
+    oasSchema.nullable = true;
+  }
 }
 
 function genProc(ctx: GenContext) {
@@ -369,6 +381,7 @@ function addResponsesFromType(
         item.itemType,
         item.attributes.description || defaultDescription,
         item.attributes.example,
+        item.attributes.oas_headers,
       );
     }
     return;
@@ -381,6 +394,8 @@ function addResponsesFromType(
         ctx,
         { type: "Plain", valueTypePath: `${unionInfo.defPath}::${item.name}` },
         item.attributes.description || defaultDescription,
+        undefined,
+        item.attributes.oas_headers,
       );
     }
     return;
@@ -397,9 +412,11 @@ function buildResponse(
   type: ir.Type,
   description?: string,
   example?: string,
+  headers?: string,
 ): OasResponse {
   const response = {} as OasResponse;
   if (description) response.description = description;
+  if (headers) response.headers = parseYaml(headers) as OasHeaders;
   if (isVoidType(type)) return response;
   const mediaType: OasMediaType = {
     schema: convertType(ctx, type),

--- a/bdl-ts/src/generator/openapi/oas-30-generator.ts
+++ b/bdl-ts/src/generator/openapi/oas-30-generator.ts
@@ -147,22 +147,20 @@ function genOneof(ctx: GenContext) {
   if (oneof.attributes.description) {
     oasSchema.description = oneof.attributes.description;
   }
-  const concreteItems = oneof.items.filter((item) =>
-    !isVoidType(item.itemType)
-  );
-  if (concreteItems.length) {
-    oasSchema.oneOf = concreteItems.map((item) => {
-      const itemSchema = convertType(ctx, item.itemType);
-      if (item.attributes.title) itemSchema.title = item.attributes.title;
-      if (item.attributes.description) {
-        itemSchema.description = item.attributes.description;
-      }
-      return itemSchema;
-    });
-  }
-  if (concreteItems.length !== oneof.items.length) {
-    oasSchema.nullable = true;
-  }
+  oasSchema.oneOf = oneof.items.map((item) => convertOneofItem(ctx, item));
+}
+
+function convertOneofItem(
+  ctx: GenContext,
+  item: ir.OneofItem,
+): oas.Oas3Schema {
+  const itemSchema: oas.Oas3Schema = isVoidType(item.itemType)
+    ? { type: "string", nullable: true, enum: [null] }
+    : convertType(ctx, item.itemType);
+  return applySchemaMetadata(itemSchema, {
+    title: item.attributes.title,
+    description: item.attributes.description,
+  });
 }
 
 function genProc(ctx: GenContext) {

--- a/docs/standard.md
+++ b/docs/standard.md
@@ -76,10 +76,13 @@ explicit `oas_*` keys rather than generic names.
 - On `struct` fields, use `oas_format` for OpenAPI string formats such as
   `email` or `date-time`.
 - On `oneof` items used in `proc` output or error types, use `oas_status` for
-  OpenAPI response status mapping and `example` for response examples.
+  OpenAPI response status mapping.
+- On response variants, use `example` for response examples and `oas_headers`
+  when you need to preserve raw OpenAPI response header definitions.
 
 The official OpenAPI generator accepts these `oas_*` keys directly and maps
 `oas_status` entries to `responses` in the generated operation schema.
+`oas_headers` should contain the OpenAPI `headers` object serialized as YAML.
 
 ## Primitive Types
 

--- a/example-schemas/swagger-petstore/generated/petstore/user.bdl
+++ b/example-schemas/swagger-petstore/generated/petstore/user.bdl
@@ -59,6 +59,17 @@ struct LoginUserInput {
 oneof LoginUserOutput {
   @ oas_status - 200
   @ description - successful operation
+  @ oas_headers
+  | X-Rate-Limit:
+  |   description: calls per hour allowed by the user
+  |   schema:
+  |     type: integer
+  |     format: int32
+  | X-Expires-After:
+  |   description: date in UTC when token expires
+  |   schema:
+  |     type: string
+  |     format: date-time
   string,
 }
 

--- a/example-schemas/swagger-petstore/scripts/convert-petstore.ts
+++ b/example-schemas/swagger-petstore/scripts/convert-petstore.ts
@@ -391,7 +391,7 @@ function buildOperationOutput(
       item.attributes.description = response.description;
     }
     if (response.headers) {
-      console.log("headers in responses are not implemented yet");
+      item.attributes.oas_headers = stringifyYaml(response.headers).trim();
     }
     const example = pickExample(response);
     if (example) item.attributes.example = JSON.stringify(example);
@@ -422,6 +422,9 @@ function buildOperationError(
     const item: ir.OneofItem = { attributes: { oas_status: status }, itemType };
     if (response.description) {
       item.attributes.description = response.description;
+    }
+    if (response.headers) {
+      item.attributes.oas_headers = stringifyYaml(response.headers).trim();
     }
     const example = pickExample(response);
     if (example) item.attributes.example = JSON.stringify(example);

--- a/standards/conventional.yaml
+++ b/standards/conventional.yaml
@@ -67,11 +67,19 @@ attributes:
       description: |-
         Provides an example value for this response variant.
         Used for generated OpenAPI response examples.
+    - key: oas_headers
+      description: |-
+        OpenAPI response header map serialized as YAML.
+        Preserves response-specific header definitions for OpenAPI round-tripping.
   bdl.union.item:
     - key: status
       description: |-
         HTTP status code for this response variant.
         Example: "200", "400", "404", "500", "default"
+    - key: oas_headers
+      description: |-
+        OpenAPI response header map serialized as YAML.
+        Preserves response-specific header definitions for OpenAPI round-tripping.
   bdl.proc:
     - key: http
       description: |-


### PR DESCRIPTION
## Summary
- preserve OpenAPI response header maps in Swagger petstore conversion via `oas_headers`
- export `oas_headers` back into OpenAPI response headers and document the attribute in the conventional standard
- allow `oneof` component schemas to contain `void` variants so petstore round-trip generation completes

## Validation
- `deno test bdl-ts/src/generator/openapi/oas-30-generator.test.ts`
- `deno run -A example-schemas/swagger-petstore/scripts/download-sources.ts`
- `deno run -A example-schemas/swagger-petstore/scripts/convert-petstore.ts`
- `deno run -A --unstable-raw-imports bdl-ts/cli/bdlc.ts openapi3 -c example-schemas/swagger-petstore/bdl.yaml`

Refs #61
Refs #63