### PR TITLE
Improve misplaced standard attribute diagnostics

### DIFF
--- a/bdl-ts/src/linter/bdl.test.ts
+++ b/bdl-ts/src/linter/bdl.test.ts
@@ -39,6 +39,63 @@ Deno.test("lintBdl requires standard by default", async () => {
   assert(messages.includes("No BDL standard specified."));
 });
 
+Deno.test("lintBdl suggests inner standard when standard is misplaced", async () => {
+  const result = await lintBdlFinal({
+    text: [
+      "@ standard - conventional",
+      "struct User {",
+      "  id: string,",
+      "}",
+      "",
+    ].join("\n"),
+  });
+  const misplacedStandardDiagnostic = result.diagnostics.find(
+    (diag) => diag.code === "bdl/misplaced-standard",
+  );
+  assertStringIncludes(
+    misplacedStandardDiagnostic?.message ?? "",
+    'Did you mean "# standard - conventional"?',
+  );
+  assertEquals(misplacedStandardDiagnostic?.span, { start: 0, end: 25 });
+  assertEquals(
+    result.diagnostics.filter((diag) => diag.code === "bdl/unknown-attribute")
+      .map((diag) => diag.message),
+    [],
+  );
+});
+
+Deno.test("lintBdl only suggests inner standard for module-level attributes", async () => {
+  const result = await lintBdlFinal({
+    text: [
+      "struct User {",
+      "  @ standard - conventional",
+      "  id: string,",
+      "}",
+      "",
+    ].join("\n"),
+    standard: conventionalStandard,
+  });
+  const codes = result.diagnostics.map((diag) => diag.code);
+  assert(codes.includes("bdl/missing-standard"));
+  assert(!codes.includes("bdl/misplaced-standard"));
+});
+
+Deno.test("lintBdl only suggests inner standard for outer attributes", async () => {
+  const result = await lintBdlFinal({
+    text: [
+      "struct User {",
+      "  # standard - conventional",
+      "  id: string,",
+      "}",
+      "",
+    ].join("\n"),
+    standard: conventionalStandard,
+  });
+  const codes = result.diagnostics.map((diag) => diag.code);
+  assert(codes.includes("bdl/missing-standard"));
+  assert(!codes.includes("bdl/misplaced-standard"));
+});
+
 Deno.test("lintBdl validates standard id from bdlConfig", async () => {
   const result = await lintBdlFinal({
     text: [

--- a/bdl-ts/src/linter/bdl.ts
+++ b/bdl-ts/src/linter/bdl.ts
@@ -280,6 +280,25 @@ async function checkStandardId(
   );
 
   if (!standardAttr) {
+    const misplacedStandardAttr = findModuleLevelStandardAttribute(
+      text,
+      bdlAst,
+    );
+    if (misplacedStandardAttr) {
+      diagnostics.push({
+        code: "bdl/misplaced-standard",
+        span: {
+          start: misplacedStandardAttr.start,
+          end: misplacedStandardAttr.end,
+        },
+        message:
+          `Outer 'standard' attributes do not set the BDL standard.\nDid you mean "${
+            formatStandardAttributeSuggestion(text, misplacedStandardAttr)
+          }"?`,
+        severity: "error",
+      });
+      return;
+    }
     diagnostics.push({
       code: "bdl/missing-standard",
       span: { start: 0, end: 0 },
@@ -310,6 +329,29 @@ async function checkStandardId(
     severity: "error",
   });
   return standardId;
+}
+
+function findModuleLevelStandardAttribute(
+  text: string,
+  bdlAst: ast.BdlAst,
+): ast.Attribute | undefined {
+  for (const statement of bdlAst.statements) {
+    const standardAttr = statement.attributes.find(
+      (attr) =>
+        text[attr.start] === "@" && slice(text, attr.name) === "standard",
+    );
+    if (standardAttr) return standardAttr;
+  }
+}
+
+function formatStandardAttributeSuggestion(
+  text: string,
+  standardAttr: ast.Attribute,
+): string {
+  const standardId = standardAttr.content
+    ? getAttributeContent(text, standardAttr).replace(/\s+/g, " ").trim()
+    : "";
+  return standardId ? `# standard - ${standardId}` : "# standard - <standard>";
 }
 
 async function checkStandard(
@@ -383,6 +425,12 @@ function checkWrongAttributeNames(ctx: CheckContext): void {
   const diagnostics = result.diagnostics;
   const attributesBySlot = groupAttributesBySlot(bdlAst);
   const validAttributeKeys = {} as Record<AttributeSlot, Set<string>>;
+  const hasModuleStandardAttr = bdlAst.attributes.some(
+    (attr) => slice(text, attr.name) === "standard",
+  );
+  const misplacedStandardAttr = hasModuleStandardAttr
+    ? undefined
+    : findModuleLevelStandardAttribute(text, bdlAst);
 
   const attributeEntries = [
     ...Object.entries(globalStandard.attributes || {}),
@@ -397,6 +445,7 @@ function checkWrongAttributeNames(ctx: CheckContext): void {
     const validAttributeKeySet = validAttributeKeys[slot as AttributeSlot];
     for (const attr of attrs as ast.Attribute[]) {
       const key = slice(text, attr.name);
+      if (attr === misplacedStandardAttr) continue;
       if (validAttributeKeySet?.has(key)) continue;
       diagnostics.push({
         code: "bdl/unknown-attribute",

--- a/deno.lock
+++ b/deno.lock
@@ -43,7 +43,7 @@
     "jsr:@ts-morph/common@0.27": "0.27.0",
     "npm:@redocly/openapi-core@1.34.1": "1.34.1",
     "npm:@rspack/core@1": "1.3.5",
-    "npm:@types/node@*": "22.5.4",
+    "npm:@types/node@*": "22.7.5",
     "npm:@types/node@^22.7.5": "22.7.5",
     "npm:@types/vscode@*": "1.94.0",
     "npm:@types/vscode@^1.92.0": "1.94.0",
@@ -54,6 +54,7 @@
     "npm:chokidar-cli@3.0.0": "3.0.0",
     "npm:js-yaml@4.1.0": "4.1.0",
     "npm:js-yaml@^4.1.0": "4.1.0",
+    "npm:jsonc-parser@3": "3.3.1",
     "npm:tsup@8.4.0": "8.4.0_typescript@5.8.2_esbuild@0.25.0_yaml@2.8.2",
     "npm:tsup@^8.4.0": "8.4.0_typescript@5.8.2_esbuild@0.25.0_yaml@2.8.2",
     "npm:typescript@^5.8.2": "5.8.2",
@@ -726,12 +727,6 @@
     },
     "@types/estree@1.0.6": {
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
-    },
-    "@types/node@22.5.4": {
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
-      "dependencies": [
-        "undici-types"
-      ]
     },
     "@types/node@22.7.5": {
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
@@ -1992,6 +1987,7 @@
         "tar-fs",
         "tunnel-agent"
       ],
+      "deprecated": true,
       "bin": true
     },
     "pump@3.0.2": {
@@ -2531,6 +2527,7 @@
           "jsr:@std/path@1",
           "jsr:@std/yaml@1",
           "npm:@redocly/openapi-core@1.34.1",
+          "npm:jsonc-parser@3",
           "npm:yaml@2"
         ]
       },


### PR DESCRIPTION
## Summary
- Detect module-level outer `standard` attributes as a likely misplaced module standard declaration
- Highlight the full misplaced attribute range and suggest the corresponding `# standard - ...` form
- Avoid treating nested or inner `standard` attributes as misplaced module standard declarations

## Tests
- `deno test -A --unstable-raw-imports --no-lock bdl-ts/src/linter/bdl.test.ts`