### PR TITLE
Add union discriminator standard attribute

### DIFF
--- a/bdl-ts/src/generated/json/conventional.json
+++ b/bdl-ts/src/generated/json/conventional.json
@@ -76,6 +76,12 @@
         "description": "HTTP status code string as provided by the OpenAPI response map.\nExample: \"200\", \"400\", \"404\", \"500\", \"default\""
       }
     ],
+    "bdl.union": [
+      {
+        "key": "discriminator",
+        "description": "Specifies the discriminator field name for tagged unions."
+      }
+    ],
     "bdl.union.item": [
       {
         "key": "status",

--- a/deno.lock
+++ b/deno.lock
@@ -43,7 +43,7 @@
     "jsr:@ts-morph/common@0.27": "0.27.0",
     "npm:@redocly/openapi-core@1.34.1": "1.34.1",
     "npm:@rspack/core@1": "1.3.5",
-    "npm:@types/node@*": "22.5.4",
+    "npm:@types/node@*": "22.7.5",
     "npm:@types/node@^22.7.5": "22.7.5",
     "npm:@types/vscode@*": "1.94.0",
     "npm:@types/vscode@^1.92.0": "1.94.0",
@@ -54,6 +54,7 @@
     "npm:chokidar-cli@3.0.0": "3.0.0",
     "npm:js-yaml@4.1.0": "4.1.0",
     "npm:js-yaml@^4.1.0": "4.1.0",
+    "npm:jsonc-parser@3": "3.3.1",
     "npm:tsup@8.4.0": "8.4.0_typescript@5.8.2_esbuild@0.25.0_yaml@2.8.2",
     "npm:tsup@^8.4.0": "8.4.0_typescript@5.8.2_esbuild@0.25.0_yaml@2.8.2",
     "npm:typescript@^5.8.2": "5.8.2",
@@ -726,12 +727,6 @@
     },
     "@types/estree@1.0.6": {
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
-    },
-    "@types/node@22.5.4": {
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
-      "dependencies": [
-        "undici-types"
-      ]
     },
     "@types/node@22.7.5": {
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
@@ -1992,6 +1987,7 @@
         "tar-fs",
         "tunnel-agent"
       ],
+      "deprecated": true,
       "bin": true
     },
     "pump@3.0.2": {
@@ -2531,6 +2527,7 @@
           "jsr:@std/path@1",
           "jsr:@std/yaml@1",
           "npm:@redocly/openapi-core@1.34.1",
+          "npm:jsonc-parser@3",
           "npm:yaml@2"
         ]
       },

--- a/standards/conventional.yaml
+++ b/standards/conventional.yaml
@@ -63,6 +63,10 @@ attributes:
       description: |-
         HTTP status code string as provided by the OpenAPI response map.
         Example: "200", "400", "404", "500", "default"
+  bdl.union:
+    - key: discriminator
+      description: |-
+        Specifies the discriminator field name for tagged unions.
   bdl.union.item:
     - key: status
       description: |-


### PR DESCRIPTION
## Summary
- Add `discriminator` as a conventional `bdl.union` attribute
- Regenerate the conventional standard JSON artifact
- Include the current lockfile updates

## Tests
- Not run (standard metadata update only)