### PR TITLE
Fix formatter block comments and missing commas

### DIFF
--- a/bdl-ts/src/formatter/bdl.ts
+++ b/bdl-ts/src/formatter/bdl.ts
@@ -447,11 +447,6 @@ function getAttributeSymbolText(
   return parser.getText(node.symbol);
 }
 
-function ensureBlankWhitespaceGap(text: string): string {
-  if (!/^\s*$/.test(text)) return text;
-  return "\n\n";
-}
-
 function separateInnerOuterAttributeLeadingTrivia<
   T extends {
     type?: string;
@@ -2035,7 +2030,11 @@ function renderUnionBlock(
       out += " " + stringifyNewlineOrComment(parser, trailingComment);
     }
   }
-  out += stringifyNewlineOrComments(parser, after).trimEnd();
+  const trailing = stringifyNewlineOrComments(parser, after).trimEnd();
+  out += indentMultilinePreserve(
+    nodes.length === 0 ? trailing.trimStart() : trailing,
+    prefix,
+  );
   return out;
 }
 
@@ -2180,8 +2179,7 @@ function listComma(
   options: { isLast: boolean; mode: "oneline" | "multiline" },
 ): string {
   if (options.mode === "oneline" && options.isLast) return "";
-  if (options.mode === "multiline" && options.isLast) return ",";
-  return comma ? ctx.f`${comma}` : "";
+  return comma ? ctx.f`${comma}` : ",";
 }
 
 function getLastSpanEnd(...nullableSpans: (cst.Span | undefined)[]) {
@@ -2276,7 +2274,8 @@ function renderCollectedBlock<T>(
         yield " " + stringifyNewlineOrComment(parser, trailingComment);
       }
     }
-    yield stringifyNewlineOrComments(parser, after).trimEnd();
+    const trailing = stringifyNewlineOrComments(parser, after).trimEnd();
+    yield nodes.length === 0 ? trailing.trimStart() : trailing;
   });
   return applyRawLineReplacements(renderedBlock, rawReplacements);
 }

--- a/bdl-ts/src/formatter/bdl/bdl.test.ts
+++ b/bdl-ts/src/formatter/bdl/bdl.test.ts
@@ -345,6 +345,34 @@ name: string, }`,
   );
 });
 
+Deno.test("regression/struct: comment-only body has no extra blank line", () => {
+  assertEquals(
+    formatForTest(`struct blabla {
+  // comment
+}`),
+    [
+      "struct blabla {",
+      "  // comment",
+      "}",
+    ].join("\n"),
+  );
+});
+
+Deno.test("regression/struct: multiline fields receive missing commas", () => {
+  assertEquals(
+    formatForTest(`struct blabla {
+  abc: string
+  def: string
+}`),
+    [
+      "struct blabla {",
+      "  abc: string,",
+      "  def: string,",
+      "}",
+    ].join("\n"),
+  );
+});
+
 Deno.test("statement/oneof: item layout and width transitions", () => {
   assertEquals(
     formatForTest(`
@@ -513,6 +541,21 @@ Done, }`,
       "enum Status {",
       "  Ready, // keep this inline comment",
       "  Done,",
+      "}",
+    ].join("\n"),
+  );
+});
+
+Deno.test("regression/enum: multiline items receive missing commas", () => {
+  assertEquals(
+    formatForTest(`enum blabla {
+  abc
+  def
+}`),
+    [
+      "enum blabla {",
+      "  abc,",
+      "  def,",
       "}",
     ].join("\n"),
   );
@@ -845,6 +888,34 @@ union Result {
       "  ReallyLongOkType,",
       "  ReallyLongErrType,",
       "  ReallyLongPendingType,",
+      "}",
+    ].join("\n"),
+  );
+});
+
+Deno.test("regression/union: comment-only body stays indented", () => {
+  assertEquals(
+    formatForTest(`union blabla {
+  // comment
+}`),
+    [
+      "union blabla {",
+      "  // comment",
+      "}",
+    ].join("\n"),
+  );
+});
+
+Deno.test("regression/union: multiline items receive missing commas", () => {
+  assertEquals(
+    formatForTest(`union blabla {
+  abc
+  def
+}`),
+    [
+      "union blabla {",
+      "  abc,",
+      "  def,",
       "}",
     ].join("\n"),
   );


### PR DESCRIPTION
## Summary

- remove the extra blank line before comments in comment-only struct and union bodies
- preserve indentation for comments inside union bodies
- insert missing commas consistently for multiline struct fields and enum/union/oneof items
- add regression coverage for the reported struct, enum, and union cases
- remove an unused formatter helper so the formatter passes lint

## Root cause

Comment-only bodies were rendered from trailing trivia without normalizing the leading newline, and the union-specific renderer did not indent that trailing trivia. The shared list-comma helper only synthesized a comma for the final multiline item, leaving earlier items unchanged when their source comma was missing.

## Impact

Formatting now produces stable, syntactically separated block items and keeps comment-only block bodies compact and correctly indented.

## Validation

- `deno test -A bdl-ts` — 109 passed, 0 failed
- `deno lint bdl-ts/src/formatter/bdl.ts bdl-ts/src/formatter/bdl/bdl.test.ts`
- `deno fmt --check bdl-ts/src/formatter/bdl.ts bdl-ts/src/formatter/bdl/bdl.test.ts`
- `deno check bdl-ts/src/formatter/bdl.ts bdl-ts/src/formatter/bdl/bdl.test.ts`